### PR TITLE
Feat : 공통 페이지 타이틀 생성

### DIFF
--- a/src/components/common/ComFuncButtons.vue
+++ b/src/components/common/ComFuncButtons.vue
@@ -1,0 +1,42 @@
+<template>
+    <q-btn :class='btnClass' :disabled='dis' type='button'
+           @click='$emit("gfnCallFunc",id,{},$event)'>
+        {{ name }}
+    </q-btn>
+</template>
+
+<script lang="ts">
+import {computed, defineComponent} from 'vue';
+
+export default defineComponent({
+    name      : 'ComFuncButtons',
+    props     : ['id', 'name', 'type', 'dis'],
+    emits: ['update:modelValue', 'gfnCallFunc'],
+    setup(props) {
+        const btnClass = computed(() => {
+            let btnClassName;
+
+            switch (props.type) {
+                //	공통 영역 버튼
+                case 'inquire'  :	//	조회
+                case 'create'   :	//	신규
+                case 'delete'   :	//	삭제
+                case 'save'     :	//	저장
+                    btnClassName = 'btn-' + props.type;
+                    break;
+                //	그 외에는 type 을 class 명 으로 받음
+                default :
+                    btnClassName = props.type;
+                    break;
+            }
+            return btnClassName;
+        });
+
+        return {
+            btnClass,
+        };
+
+    },
+
+});
+</script>

--- a/src/components/common/ComFuncButtons.vue
+++ b/src/components/common/ComFuncButtons.vue
@@ -24,7 +24,7 @@ export default defineComponent({
                 case 'save'     :	//	저장
                     btnClassName = 'btn-' + props.type;
                     break;
-                //	그 외에는 type 을 class 명 으로 받음
+                // 그 외에는 type을 class명으로 받음
                 default :
                     btnClassName = props.type;
                     break;

--- a/src/layouts/LayoutPageTitle.vue
+++ b/src/layouts/LayoutPageTitle.vue
@@ -2,7 +2,7 @@
     <div class="page_tit">
         {{pageTitle}}
     </div>
-    <div id='cmmnBtns' class="comm_btn">
+    <div id='comBtns' class="com_btn">
         <com-func-buttons
                 v-for="btn in funcButtons"
                 v-show="! btn.hide"
@@ -95,4 +95,4 @@ export default defineComponent({
     }
 });
 
-</script>b
+</script>

--- a/src/layouts/LayoutPageTitle.vue
+++ b/src/layouts/LayoutPageTitle.vue
@@ -19,25 +19,19 @@
 
 <script lang="ts">
 import {defineComponent, ref} from 'vue';
-import ComFuncButtons from '@/components/common/ComFuncButtons.vue';
 import {useRoute} from 'vue-router';
-import cinitial from '@/composables/comInitialize';
-import {AuthButtons, AuthButtonsType, ButtonAuths, FuncButtons } from '@/types/CommonTypes';
+import ComFuncButtons from '@/components/common/ComFuncButtons.vue';
+import { ButtonAuths, FuncButtons } from '@/types/CommonTypes';
 
 export default defineComponent({
     name      : 'LayoutPageTitle',
     components: {ComFuncButtons},
-    props     : ['fnCallFunc', 'disableBtns', 'hideBtns'],
+    props     : ['fnCallFunc'],
     setup(props) {
         const route = useRoute();
         const funcButtons = ref(<FuncButtons[]>[]);
-        const disableBtns = ref({} as AuthButtons);
-        const hideBtns = ref({} as AuthButtons);
         const fnCallFunc = ref(props.fnCallFunc);
         const pageTitle = route.meta.title;
-
-        disableBtns.value = cinitial.$inItData('rowData', AuthButtonsType) as unknown as AuthButtons;
-        hideBtns.value = cinitial.$inItData('rowData', AuthButtonsType) as unknown as AuthButtons;
 
         (async () => {
             pushFucnButtons('inquire', '조회', 'inquire', true, false, false);
@@ -50,12 +44,12 @@ export default defineComponent({
         function pushFucnButtons(id: string, name: string, type: string, stat: boolean, dis: boolean, hide: boolean) {
             if (stat) {
                 funcButtons.value.push({
-                    id    : id
-                    , name: name
-                    , type: type
-                    , stat: stat
-                    , dis : dis
-                    , hide: hide,
+                    id   : id,
+                    name : name,
+                    type : type,
+                    stat : stat,
+                    dis  : dis,
+                    hide : hide,
                 });
             }
         }
@@ -90,7 +84,6 @@ export default defineComponent({
                     btnAuth = false;
                     return;
             }
-
             fnCallFunc.value(id, ev);
         }
 

--- a/src/layouts/LayoutPageTitle.vue
+++ b/src/layouts/LayoutPageTitle.vue
@@ -1,0 +1,105 @@
+<template>
+    <div class="page_tit">
+        {{pageTitle}}
+    </div>
+    <div id='cmmnBtns' class="comm_btn">
+        <com-func-buttons
+                v-for="btn in funcButtons"
+                v-show="! btn.hide"
+                v-bind:id="btn.id"
+                v-bind:key="btn.id"
+                v-bind:dis="btn.dis"
+                v-bind:name="btn.name"
+                v-bind:stat="btn.stat"
+                v-bind:type="btn.type"
+                @gfnCallFunc="gfnCallFunc"
+        />
+    </div>
+</template>
+
+<script lang="ts">
+import {defineComponent, ref} from 'vue';
+import ComFuncButtons from '@/components/common/ComFuncButtons.vue';
+import {useRoute} from 'vue-router';
+import cinitial from '@/composables/comInitialize';
+import {AuthButtons, AuthButtonsType, ButtonAuths, FuncButtons } from '@/types/CommonTypes';
+
+export default defineComponent({
+    name      : 'LayoutPageTitle',
+    components: {ComFuncButtons},
+    props     : ['fnCallFunc', 'disableBtns', 'hideBtns'],
+    setup(props) {
+        const route = useRoute();
+        const funcButtons = ref(<FuncButtons[]>[]);
+        const disableBtns = ref({} as AuthButtons);
+        const hideBtns = ref({} as AuthButtons);
+        const fnCallFunc = ref(props.fnCallFunc);
+        const pageTitle = route.meta.title;
+
+        disableBtns.value = cinitial.$inItData('rowData', AuthButtonsType) as unknown as AuthButtons;
+        hideBtns.value = cinitial.$inItData('rowData', AuthButtonsType) as unknown as AuthButtons;
+
+        (async () => {
+            pushFucnButtons('inquire', '조회', 'inquire', true, false, false);
+            pushFucnButtons('create', '신규', 'create', true, false, false);
+            pushFucnButtons('delete', '삭제', 'delete', true, false, false);
+            pushFucnButtons('save', '저장', 'save', true, false, false);
+        })();
+
+        // funcButton 생성하는 함수
+        function pushFucnButtons(id: string, name: string, type: string, stat: boolean, dis: boolean, hide: boolean) {
+            if (stat) {
+                funcButtons.value.push({
+                    id    : id
+                    , name: name
+                    , type: type
+                    , stat: stat
+                    , dis : dis
+                    , hide: hide,
+                });
+            }
+        }
+
+        //	공통권한버튼 클릭시 호출
+        function gfnCallFunc(id: string, ev: Event) {
+            let btnAuth = true;
+            const btnAuths = funcButtons.value as unknown as ButtonAuths;
+
+            switch (id) {
+                case 'inquire':
+                    if (!btnAuths.inquire) {
+                        btnAuth = false;
+                    }
+                    break;
+                case 'create':
+                    if (!btnAuths.create) {
+                        btnAuth = false;
+                    }
+                    break;
+                case 'delete':
+                    if (!btnAuths.delete) {
+                        btnAuth = false;
+                    }
+                    break;
+                case 'save':
+                    if (!btnAuths.save) {
+                        btnAuth = false;
+                    }
+                    break;
+                default:
+                    btnAuth = false;
+                    return;
+            }
+
+            fnCallFunc.value(id, ev);
+        }
+
+        return {
+            funcButtons,
+            gfnCallFunc,
+            pageTitle
+        };
+    }
+});
+
+</script>b

--- a/src/pages/Admin/Group.vue
+++ b/src/pages/Admin/Group.vue
@@ -1,28 +1,26 @@
 <template>
     <div>
-        Group Page
+        <layout-page-title
+                :fnCallFunc="fnCallFunc"
+        />
         <br>
         <date-picker :id="groupParams.debutDate" v-model='groupParams.debutDate' :clearable='true'/>
         <br>
-        <select-box id="artist" v-model='groupParams.artist'
-                        v-bind='selectBoxOptions.artist' />
-        <br>
-        {{groupParams}}
+        <select-box id="artist" v-model='groupParams.artist' v-bind='selectBoxOptions.artist' />
     </div>
 </template>
 
 <script lang="ts">
 import {defineComponent, ref} from 'vue';
+import mixinPageCommon from '@/pages/mixin/mixinPageCommon';
 import ccobject from '@/composables/createComObject';
 import cinitial from '@/composables/comInitialize';
 import cscript from '@/composables/comScripts';
-import DatePicker from '@/components/common/datePicker.vue';
-import SelectBox from '@/components/common/selectBox.vue';
 import {Group, GroupType} from '@/types/Group';
 
 export default defineComponent({
     name        : 'Group',
-    components  : {DatePicker, SelectBox},
+    mixins: [mixinPageCommon],
     setup(){
         const groupParams = ref({} as Group);
         const {selectBoxOptions: selectBoxOptions} = ccobject.$createSelectAll(['artist']);
@@ -35,6 +33,9 @@ export default defineComponent({
             const tempList = [{
                 'codeNm': '김원필',
                 'codeValue': '940428'
+            },{
+                'codeNm': '윤도운',
+                'codeValue': '950825'
             }];
 
             // 아티스트 셀렉트 옵션
@@ -46,7 +47,23 @@ export default defineComponent({
             selectBoxOptions.value.artist.data = await cscript.$getComboOptions(tempList);
         })();
 
+        function fnCallFunc(id: string) {
+            switch (id) {
+                case 'inquire'  :   // 조회
+                    break;
+                case 'create'   :   // 신규
+                    break;
+                case 'delete'   :   // 삭제
+                    break;
+                case 'save'     :   // 저장
+                    break;
+                default:
+                    break;
+            }
+        }
+
         return{
+            fnCallFunc,
             groupParams,
             selectBoxOptions
         };

--- a/src/pages/mixin/mixinPageCommon.ts
+++ b/src/pages/mixin/mixinPageCommon.ts
@@ -1,0 +1,15 @@
+import {defineComponent} from 'vue';
+import LayoutPageTitle from '@/layouts/LayoutPageTitle.vue';
+import DatePicker from '@/components/common/datePicker.vue';
+import SelectBox from '@/components/common/selectBox.vue';
+import {AgGridVue} from '@ag-grid-community/vue3';
+
+export default defineComponent({
+    components: {
+        LayoutPageTitle,
+        AgGridVue,
+        DatePicker,
+        SelectBox,
+    },
+    setup() {}
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,18 +2,22 @@ import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 
 const routes: Array<RouteRecordRaw> = [
   {
+    meta: {title: 'Home'},
     path: '/',
     component: () => import('@/pages/Home.vue'),
   },
   {
+    meta: {title: '관리자 화면'},
     path: '/admin',
     component: () => import('@/pages/Admin/Admin.vue'),
   },
   {
+    meta: {title: '그룹 추가 화면'},
     path: '/admin/group',
     component: () => import('@/pages/Admin/Group.vue'),
   },
   {
+    meta: {title: '아티스트 추가 화면'},
     path: '/admin/artists',
     component: () => import('@/pages/Admin/Artists.vue'),
   },

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -28,3 +28,40 @@ export interface CommonCode extends CommonRowData {
     codeValue: string,
     codeNm: string,
 }
+
+export interface FuncButtons {
+    id: string;
+    name: string;
+    type: string;
+    stat: boolean;
+    dis: boolean;
+    hide: boolean;
+}
+
+export interface AuthButtons {
+    inquire: boolean;
+    create: boolean;
+    delete: boolean;
+    save: boolean;
+    excel: boolean;
+    skll1: boolean;
+    skll2: boolean;
+    skll3: boolean;
+}
+
+export interface ButtonAuths extends AuthButtons {
+    menuId: string;
+    authorGroup: string;
+}
+
+const AuthButtonsType: { [key: string]: string } = {
+    inquire: ' boolean',
+    create : ' boolean',
+    delete : ' boolean',
+    save   : ' boolean',
+    excel  : ' boolean',
+    skll1  : ' boolean',
+    skll2  : ' boolean',
+    skll3  : ' boolean',
+};
+export {AuthButtonsType};

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -43,25 +43,9 @@ export interface AuthButtons {
     create: boolean;
     delete: boolean;
     save: boolean;
-    excel: boolean;
-    skll1: boolean;
-    skll2: boolean;
-    skll3: boolean;
 }
 
 export interface ButtonAuths extends AuthButtons {
     menuId: string;
     authorGroup: string;
 }
-
-const AuthButtonsType: { [key: string]: string } = {
-    inquire: ' boolean',
-    create : ' boolean',
-    delete : ' boolean',
-    save   : ' boolean',
-    excel  : ' boolean',
-    skll1  : ' boolean',
-    skll2  : ' boolean',
-    skll3  : ' boolean',
-};
-export {AuthButtonsType};


### PR DESCRIPTION
## 🛠 주요 변경 사항 
1. 공통 사용 컴포넌트 import 파일 생성
    - /pages/mixin/mixinPageCommon.ts 생성
    - 추후 추가되는 공통 컴포넌트를 해당 파일에 추가
    - 화면.vue에는 mixinPageCommon.ts만 import

2. 페이지 상단 타이틀과 공통 버튼(조회, 신규, 삭제, 저장) 생성
    - /layouts/LayoutPageTitle.vue 생성
    - mixinPageCommon.ts에 import
    - 상단 타이틀 : router에 meta.title 추가 후 데이터 불러오기
    - 공통 버튼 : ComFuncButtons.vue 생성하여 사용

## 구현 화면
![그룹 추가 화면](https://user-images.githubusercontent.com/68046496/213388967-df8e2c57-87af-469c-906a-eb01df533dcc.png)