### PR TITLE
Feat/admin : 그룹 입력 화면 구현

### DIFF
--- a/src/components/common/datePicker.vue
+++ b/src/components/common/datePicker.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <q-input ref="inputRef" v-model="val" :clearable="clearable" :dense="true"
+        <q-input ref="inputRef" v-model="val" :clearable="clearable" :dense="true" outlined
                  :mask='maskFormat' :readonly="readonly" >
             <template v-slot:append>
                 <q-icon class="cursor-pointer" name="event">

--- a/src/composables/axiosUtils.ts
+++ b/src/composables/axiosUtils.ts
@@ -1,0 +1,22 @@
+import {ResultModel, ToSaveData} from '@/types/CommonTypes';
+// import cscript from '@/composables/comScripts';
+// import axios from 'axios';
+
+export default {
+    // 데이터 삭제
+    async $deleteData(url: string, toDeleteData?: ToSaveData): Promise<ResultModel> {
+        let resultModel = {} as ResultModel;
+        console.log('삭제 시작 : ');
+
+        return resultModel
+    },
+
+    //데이터 저장
+    async $saveData(url: string, toSaveData: ToSaveData | ToSaveData[], postGb = false): Promise<ResultModel> {
+
+        let resultModel = {} as ResultModel;
+        console.log('저장시작 : ');
+
+        return resultModel;
+    },
+}

--- a/src/composables/comInitialize.ts
+++ b/src/composables/comInitialize.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import {AllCommunityModules} from '@ag-grid-community/all-modules';
 
 /*
 * 데이터를 타입 정의에 맞게 초기화
@@ -25,5 +26,19 @@ export default {
         });
 
         return tempData;
+    },
+
+    $comGridOption: {
+        modules                : AllCommunityModules,
+        defaultColDef          : {
+            editable    : false, // 입력가능
+            sortable    : false, // 정렬가능
+            resizable   : false, // 사이즈조절가능
+            filter      : true, // 필터 *현황은 필수
+            lockPosition: true, // 컬럼 드래그 방지
+            width       : 100,
+        },
+        localeText             : {noRowsToShow: '조회 결과가 없습니다.'},
+        enableCellTextSelection: true,
     },
 }

--- a/src/composables/comScripts.ts
+++ b/src/composables/comScripts.ts
@@ -41,4 +41,49 @@ export default {
         });
         return cpListItems;
     },
+
+    /**
+     * 데이터 비교
+     * @desc 2개의 데이터(json)를 비교 후, 변경 된 부분의 값을 반환
+     * ==============================================================================================================
+     *
+     *   [[[[[[[[[[[[ 데이터(json) 비교 ]]]]]]]]]]]]]]]
+     *     - 데이터1                  - 데이터2               -키이름 배열
+     *     {a:1, b:2}                 {a:1, b:999}           ['a', 'b']
+     *
+     * comScripts.$compareDatas(데이터1, 데이터2, 키이름 배열)
+     * ompResult = await cscript.$compareDatas<CodeGroup>(detailData.value, detailOrgData.value, ['item1Nm']);
+     *
+     * - 결과
+     * [
+     *    {'keyName' : 'b', 'data1' : 2, 'data2': 999}
+     * ]
+     *
+     *  - 설명
+     *   rowNum : 'b' : 다른 키 이름, 'data1': 데이터 1번 파라미터 의 값, 'data2': 데이터 2번 파라미터의 값
+     *
+     * @return 비교 항목
+     * @param obj1
+     * @param obj2
+     * @param xcptKeyLists
+     */
+    $compareDatas: async function $compareDatas<T>(obj1: T, obj2: T, xcptKeyLists: string[] = []) {
+        const rtnValue = [] as { keyNm: string, data1: unknown, data2: unknown }[];
+        const tempKeyList = _.uniq((Object.keys(obj1 as any) as (keyof T)[]).concat(Object.keys(obj2 as any) as (keyof T)[]));
+
+        await _.forEach(tempKeyList, (keyNm: keyof T) => {
+            //제외 키 인지 확인
+            const isXcptKey = _.includes(xcptKeyLists as any, keyNm);
+            //둘중 하나라도 값이 있고, 제외키가 아니고, 둘의 값이 일치하지 않을 때
+            if (!(this.$isEmpty(obj1[keyNm]) && this.$isEmpty(obj2[keyNm])) && !isXcptKey && obj1[keyNm] != obj2[keyNm]) {
+                rtnValue.push({
+                    keyNm: keyNm as string,
+                    data1: obj1[keyNm],
+                    data2: obj2[keyNm],
+                });
+            }
+        });
+
+        return rtnValue;
+    },
 }

--- a/src/composables/createComObject.ts
+++ b/src/composables/createComObject.ts
@@ -1,6 +1,7 @@
 import {ref} from 'vue';
 import _ from 'lodash';
-import {CommonSelectBox} from '@/types/CommonTypes';
+import {CommonGrdProps, CommonSelectBox} from '@/types/CommonTypes';
+import {ColumnApi, GridApi, GridReadyEvent, PaginationChangedEvent} from '@ag-grid-community/core';
 
 export default {
     $createSelectAll: function createSelectAll(names: string[]) {
@@ -12,5 +13,38 @@ export default {
             });
         }
         return {selectBoxOptions};
+    },
+
+    $createComGrd: function createComGrd<T>() {
+        // 그리드 변수
+        const grdApi = ref({} as GridApi);
+        const columnApi = ref({} as ColumnApi);
+        const grdCnt = ref(0);
+        const grdColKey = ref('id');
+
+        interface GrdProps extends CommonGrdProps {
+            rowData: T[],
+        }
+
+        const grdProps = ref({} as GrdProps);
+
+        function onGridReady(event: GridReadyEvent) {
+            grdApi.value = event.api;
+            columnApi.value = event.columnApi;
+            grdApi.value.setHeaderHeight(37);
+        }
+
+        async function onPaginationChanged(event: PaginationChangedEvent) {
+            // console.log(event.type, ' : newData : ', event.newData, 'newPage : ', event.newPage, 'keepRenderedRows : ', event.keepRenderedRows, 'animate : ', event.animate);
+            if (event.newPage) { // 사용자가 페이지를 이동한 경우 → 되돌아가는 경우랑 이동하는 경우는 달라야함
+                // console.log('newPage!');
+                const firstRenderedNode = await grdApi.value.getRenderedNodes()[0];
+                // 사용자가 페이지를 바꿀때마다 첫번째 행 선택
+                await grdApi.value.setFocusedCell(firstRenderedNode.rowIndex as number, grdColKey.value);
+                // console.log('setFocusedCell 끝');
+            }
+        }
+
+        return {grdApi, columnApi, grdCnt, grdColKey, grdProps, onGridReady, onPaginationChanged};
     },
 }

--- a/src/composables/customAgGridUtils.ts
+++ b/src/composables/customAgGridUtils.ts
@@ -1,0 +1,47 @@
+import {ValueFormatterParams} from '@ag-grid-community/core';
+
+export const GrdHeaderHeight = 38;
+const GrdPageNation = 32;
+const GrdScroll = 15;
+
+export default {
+    // 그리드 높이 계산을 위함
+    $getGridStyle(showRowCnt: number) {
+        const height = (showRowCnt * 27) + GrdHeaderHeight + GrdPageNation + GrdScroll + 3.2;
+        return 'width: 100%; height: ' + height + 'px;';
+    },
+}
+
+export function PhoneNumFormatter(params: ValueFormatterParams) {
+    if (!params.value) {
+        return '-';
+    }
+    if (params.value.charAt(0) === '+') { //국제전화인지 확인
+        if (params.value.substring(0, 3) === '+82') { //한국인지 확인
+            if (params.value.length === 11) {
+                // +82 2 123 4567 : 서울 지역번호로 국제전화
+                return params.value.replace(/(.\d{2})(\d)(\d{3})(\d{4})/, '$1-$2-$3-$4');
+            }
+            if (params.value.length === 12) {
+                return params.value.replace(/(.\d{2})(\d{2})(\d{3})(\d{4})/, '$1-$2-$3-$4');
+            }
+            if (params.value.length === 13) {
+                return params.value.replace(/(.\d{2})(\d{2})(\d{4})(\d{4})/, '$1-$2-$3-$4');
+            }
+        }
+    } else { //국제전화 아님
+        if (params.value.length < 9) {
+            return params.value;
+        }
+        if (params.value.length === 9) {
+            return params.value.replace(/(\d{2})(\d{3})(\d{4})/, '$1-$2-$3');
+        }
+        if (params.value.length === 10) {
+            return params.value.replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+        }
+        if (params.value.length === 11) {
+            return params.value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+        }
+    }
+    return params.value;
+}

--- a/src/layouts/LayoutPageTitle.vue
+++ b/src/layouts/LayoutPageTitle.vue
@@ -94,5 +94,4 @@ export default defineComponent({
         };
     }
 });
-
 </script>

--- a/src/pages/Admin/Group.vue
+++ b/src/pages/Admin/Group.vue
@@ -3,30 +3,135 @@
         <layout-page-title
                 :fnCallFunc="fnCallFunc"
         />
-        <br>
-        <date-picker :id="groupParams.debutDate" v-model='groupParams.debutDate' :clearable='true'/>
-        <br>
-        <select-box id="artist" v-model='groupParams.artist' v-bind='selectBoxOptions.artist' />
+
+        <div class='form_table'>
+            <table>
+                <colgroup>
+                    <col style='width:120px'/>
+                    <col style='width:auto'/>
+                    <col style='width:120px'/>
+                    <col style='width:auto'/>
+                </colgroup>
+                <tbody>
+                <tr>
+                    <th>로고 파일</th>
+                    <td colspan="3">
+                        <q-file :ref='el => { divs["logo"] = el }' outlined v-model="groupParams.logo" accept=".jpg, .png, image/*" @rejected="onRejected">
+                            <template v-slot:prepend>
+                                <q-icon name="attach_file" />
+                            </template>
+                        </q-file>
+                    </td>
+                </tr>
+                <tr>
+                    <th>그룹명</th>
+                    <td>
+                        <q-input :ref='el => { divs["name"] = el }' v-model="groupParams.name" :dense="true" maxlength="100" outlined/>
+                    </td>
+                    <th>영문 그룹명</th>
+                    <td>
+                        <q-input :ref='el => { divs["englishName"] = el }' v-model="groupParams.englishName" :dense="true" maxlength="100" outlined/>
+                    </td>
+                </tr>
+                <tr>
+                    <th>데뷔일</th>
+                    <td colspan="3">
+                        <date-picker :ref='el => { divs["debutDate"] = el }' :id="groupParams.debutDate" v-model='groupParams.debutDate' :clearable='true'/>
+                    </td>
+                </tr>
+                <tr>
+                    <th>아티스트</th>
+                    <td colspan="3">
+                        <select-box id="artist" v-model='artistList' v-bind='selectBoxOptions.artist' style="width: 100%;"
+                                    :multiplied='true'
+                                    use-chips/>
+                    </td>
+                </tr>
+                <tr>
+                    <th>공식 컬러</th>
+                    <td colspan="3">
+                        <q-input outlined v-model="groupParams.color">
+                            <template v-slot:append>
+                                <q-icon name="colorize" class="cursor-pointer">
+                                    <q-popup-proxy cover transition-show="scale" transition-hide="scale">
+                                        <q-color v-model="groupParams.color" />
+                                    </q-popup-proxy>
+                                </q-icon>
+                            </template>
+                        </q-input>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div>
+            <div class='con_tit'>
+                <h6>그룹 목록</h6>
+                <p class='num'>[총 {{ grdMstCnt }} 건]</p>
+            </div>
+            <div id='grdMstArea' class="grid_edge">
+                <div class='default-list'>
+                    <ag-grid-vue
+                            id='grdMst'
+                            ref='grdMst'
+                            v-bind='grdMstProps'
+                            class='ag-theme-balham'
+                            @grid-ready="onGridReady"
+                            @pagination-changed="onPaginationChanged"
+                    />
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
 import {defineComponent, ref} from 'vue';
-import mixinPageCommon from '@/pages/mixin/mixinPageCommon';
+import { useQuasar } from 'quasar';
+import _ from 'lodash';
+import mixinPageCommon from '../mixin/mixinPageCommon';
 import ccobject from '@/composables/createComObject';
 import cinitial from '@/composables/comInitialize';
 import cscript from '@/composables/comScripts';
+// import apis from '@/composables/axiosUtils';
+import caggrid from '@/composables/customAgGridUtils';
 import {Group, GroupType} from '@/types/Group';
+import { ToSaveData } from '@/types/CommonTypes';
+import { GetRowIdParams, GridOptions } from '@ag-grid-community/core';
 
 export default defineComponent({
     name        : 'Group',
     mixins: [mixinPageCommon],
     setup(){
+        const $q = useQuasar()
         const groupParams = ref({} as Group);
+        const groupParamsOrgData = ref({} as Group);
         const {selectBoxOptions: selectBoxOptions} = ccobject.$createSelectAll(['artist']);
+
+        // 템플릿 내 ref 사용을 위한 div 변수 셋팅
+        const divs = ref({} as { [key: string]: unknown });
+
+        // 아티스트 멀티 셀렉트박스 배열 변수
+        const artistList = ref([] as string[]);
+        const artistListOrgData = ref([] as string[]);
+
+        let pCurMstRowKey = -1;
 
         // 데이터 초기화
         groupParams.value = cinitial.$inItData('', GroupType) as unknown as Group;
+        groupParamsOrgData.value = cinitial.$inItData('', GroupType) as unknown as Group;
+
+        // 그리드 변수
+        const {
+            grdApi,
+            //columnApi,
+            grdCnt   : grdMstCnt,
+            grdColKey: grdMstKey,
+            grdProps : grdMstProps,
+            onGridReady,
+            onPaginationChanged,
+        } = ccobject.$createComGrd<Group>();
 
         (async () => {
             // 아티스트 정보 가져오기
@@ -47,15 +152,167 @@ export default defineComponent({
             selectBoxOptions.value.artist.data = await cscript.$getComboOptions(tempList);
         })();
 
+        grdMstCnt.value = 0;
+        grdMstProps.value = Object.assign({}, cinitial.$comGridOption, {
+            name                         : 'grdMstProps',
+            columnDefs                   : [
+                {headerName: 'No', valueGetter: 'node.rowIndex + 1', width: 60, sortable: true},
+                {headerName: '그룹명', field: 'name', width: 150, cellStyle : {textAlign: 'left'}},
+                {headerName: '영문 그룹명', field: 'englishName', width: 150, cellStyle : {textAlign: 'left'}},
+                {headerName: '데뷔일', field: 'debutDate', width: 150, cellStyle : {textAlign: 'left'}},
+                {headerName: 'ID', field: '_id', hide: true}
+            ],
+            rowData                      : [],
+            getRowId                     : (params: GetRowIdParams) => params.data._id,
+            style                 : caggrid.$getGridStyle(10), // 보여주고싶은 행 숫자
+            pagination        : true,
+            paginationAutoPageSize: true,
+            animateRows       : true,
+            rowSelection      : 'single',
+        } as GridOptions) as unknown as typeof grdMstProps.value;
+
+        // 로고 파일 업로드 제한
+        function onRejected(){
+            alert('.jpg, .png 파일만 업로드 가능합니다.');
+        }
+
+        // 변경사항 체크
+        async function checkDiffData() {
+            let diffMst = false;
+
+            const compResult = await cscript.$compareDatas<Group>(groupParams.value, groupParamsOrgData.value);
+            // console.log("compResult : ", compResult);
+
+            if (compResult.length != 0) {
+                diffMst = true; // 변경 사항 있음.
+            }
+
+            return diffMst;
+        }
+
+        // 필수 입력 항목 체크
+        async function isMstValid() {
+            // 로고, 그룹명, 영문 그룹명. 데뷔일
+            if (cscript.$isEmpty(groupParams.value.logo)) {
+                alert('로고 파일은 필수입니다.');
+                (divs.value.logo as HTMLInputElement).focus();
+                return false;
+            }
+            if (cscript.$isEmpty(groupParams.value.name)) {
+                alert('그룹명은 필수입니다.');
+                (divs.value.name as HTMLInputElement).focus();
+                return false;
+            }
+            if (cscript.$isEmpty(groupParams.value.englishName)) {
+                alert('영문 그룹명은 필수입니다.');
+                (divs.value.englishName as HTMLInputElement).focus();
+                return false;
+            }
+            if (cscript.$isEmpty(groupParams.value.debutDate)) {
+                alert('데뷔일은 필수입니다.');
+                (divs.value.debutDate as HTMLInputElement).focus();
+                return false;
+            }
+            return true;
+        }
+
+        // 그리드 초기화
+        function grdReset() {
+            grdApi.value.setRowData([]);
+            grdMstCnt.value = 0;
+            grdApi.value.deselectAll();
+            pCurMstRowKey = -1;
+
+            // 아티스트 초기화
+            artistList.value.splice(0, artistList.value.length);
+            artistListOrgData.value = _.cloneDeep(artistList.value);
+        }
+
+        async function fnInquire() {
+            const msg = '변경된 내용이 있습니다. 신규 작성시 변경 내용이 사라집니다.계속 하시겠습니까?';
+            if ((await checkDiffData()) && !confirm(msg)) {
+                return;
+            }
+
+            // 조회 호출
+            await getMstList();
+        }
+
+        // 그리드 조회
+        async function getMstList(pkKey?: string | number) {
+            // 그리드 데이터 초기화
+            grdReset();
+
+        }
+
+        async function fnNew() {
+            const msg = '변경된 내용이 있습니다. 신규 작성시 변경 내용이 사라집니다.계속 하시겠습니까?';
+            if ((await checkDiffData()) && !confirm(msg)) {
+                return;
+            }
+
+            // 데이터 초기화
+            groupParams.value = {} as Group;
+            groupParamsOrgData.value = _.cloneDeep(groupParams.value);
+
+            // 아티스트 배열 초기화
+            artistList.value.splice(0, artistList.value.length);
+            artistListOrgData.value = _.cloneDeep(artistList.value);
+
+            // 로고 파일 입력창에 포커스
+            (divs.value.logo as HTMLInputElement).focus();
+        }
+
+        async function fnDelete() {
+            await deleteRowData();
+        }
+
+        async function deleteRowData() {
+            const url = '';
+            // const saveResult = await apis.$deleteData(url);
+            // alert('저장 완료하였습니다.');
+        }
+
+        async function fnSave(){
+            // 변경사항 체크
+            const groupDiff = await checkDiffData();
+
+            console.log('groupDiff : ', groupDiff);
+
+            if (!groupDiff) {
+                alert('변경 사항이 없습니다.')
+                return;
+            }
+
+            if (!await isMstValid()) {
+                return;
+            }
+
+            // 저장 데이터 생성
+            const toSaveData = Object.assign({} as ToSaveData, groupParams.value);
+            // console.log('toSaveData', toSaveData);
+            await saveRowData(toSaveData);
+        }
+
+        async function saveRowData(toSaveData: ToSaveData) {
+            const url = '';
+            // const saveResult = await apis.$saveData(url, toSaveData);
+            // alert('저장 완료하였습니다.');
+        }
+
         function fnCallFunc(id: string) {
             switch (id) {
                 case 'inquire'  :   // 조회
+                    fnInquire();
                     break;
                 case 'create'   :   // 신규
+                    fnNew();
                     break;
                 case 'delete'   :   // 삭제
+                    fnDelete();
                     break;
                 case 'save'     :   // 저장
+                    fnSave();
                     break;
                 default:
                     break;
@@ -63,9 +320,16 @@ export default defineComponent({
         }
 
         return{
+            divs,
             fnCallFunc,
+            grdMstCnt,
+            grdMstProps,
+            onGridReady,
+            onPaginationChanged,
             groupParams,
-            selectBoxOptions
+            selectBoxOptions,
+            onRejected,
+            artistList,
         };
     }
 });
@@ -73,5 +337,36 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.form_table {
+    padding: 20px 10px;
+}
+
+.form_table table {
+    border-collapse : collapse;
+    border-spacing  : 0;
+    font-size       : 12px;
+    text-align      : center;
+    width           : 100%;
+    table-layout    : fixed;
+    border-top      : 1px solid #DDF1FF;
+    border-bottom   : 1px solid #DDF1FF;
+    letter-spacing  : -0.07em;
+}
+
+.form_table table thead tr th {
+    background    : rgba(79, 190, 159, 0.2);
+    height        : 26px;
+    border-bottom : 1px solid #CCEFF1;
+    padding       : 7px 0;
+}
+
+.form_table table tbody tr th {
+    background    : #DDF1FF;
+    height        : 26px;
+    border-bottom : 1px solid #A8E3F1;
+    text-align    : center;
+    padding       : 5px 0;
+    line-height   : 26px;
+}
 
 </style>

--- a/src/pages/mixin/mixinPageCommon.ts
+++ b/src/pages/mixin/mixinPageCommon.ts
@@ -3,6 +3,11 @@ import LayoutPageTitle from '@/layouts/LayoutPageTitle.vue';
 import DatePicker from '@/components/common/datePicker.vue';
 import SelectBox from '@/components/common/selectBox.vue';
 import {AgGridVue} from '@ag-grid-community/vue3';
+import '@ag-grid-community/core/dist/styles/ag-grid.css'; // Core grid CSS, always needed
+import '@ag-grid-community/core/dist/styles/ag-theme-alpine.css';
+import '@ag-grid-community/core/dist/styles/ag-theme-material.css';
+import '@ag-grid-community/core/dist/styles/ag-theme-balham.css';
+import '@ag-grid-community/core/dist/styles/ag-theme-blue.css';
 
 export default defineComponent({
     components: {

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -1,3 +1,6 @@
+import {GridOptions} from '@ag-grid-community/core';
+import {AllCommunityModules} from '@ag-grid-community/all-modules';
+
 export interface CommonSelect {
     label: string;
     value: string;
@@ -48,4 +51,29 @@ export interface AuthButtons {
 export interface ButtonAuths extends AuthButtons {
     menuId: string;
     authorGroup: string;
+}
+
+export interface ToSaveData {
+    [p: string]: unknown;
+}
+
+export interface ResultModel {
+    name: string;
+    successCnt: number;
+    errorCnt: number;
+    retMsg: string;
+    retCode: string;
+}
+
+export interface CommonGrdProps extends GridOptions {
+    name: string,
+    modules: typeof AllCommunityModules,
+    //columnDefs: ColDef[],
+    //defaultColDef: ColDef,
+    style: string,
+    //pagination: boolean,       // pagination properties
+    //paginationPageSize?: number,
+    // columnTypes?: {
+    //   [key: string]: ColDef;
+    // },
 }


### PR DESCRIPTION
## 🛠 주요 변경 사항 
1. 그룹 필수 + 선택 입력 화면 구현
    - 로고 파일 업로드 및 공식 컬러 팔레트 Input 추가
    - 아티스트 셀렉트 박스 멀티로 변경
    - Group.vue 하단 form + table css 추가

2. 그룹 목록 AG-Grid 추가
    - AG-Grid 공통 사용 함수 파일 추가 (customAgGridUtils.ts)

※ 백엔드 서버와 통신 부분은 추가하지 않은 화면 구현 단계입니다.

## 구현 화면
![230123_그룹 입력 화면 구현](https://user-images.githubusercontent.com/68046496/214058664-d8be0bff-2173-457c-92e0-dad22023b1cb.png)
