### PR TITLE
서버 통신 시 Token 추가 

### DIFF
--- a/src/graphql/signIn.mutate.gql
+++ b/src/graphql/signIn.mutate.gql
@@ -1,10 +1,13 @@
 mutation ($token: String!, $provider: String) {
-  user: signIn (accessToken: $token, provider: $provider) {
-    _id
-    name
-    email
-    provider
-    providerId
-    image
+  auth: signIn (accessToken: $token, provider: $provider) {
+    user {
+      _id
+      name
+      email
+      provider
+      providerId
+      image
+    }
+    token
   }
 }

--- a/src/plugins/villus.ts
+++ b/src/plugins/villus.ts
@@ -1,9 +1,15 @@
-import { createClient } from 'villus';
+import { createClient, defaultPlugins, FetchOptions } from 'villus';
 
 const host: string = 'http://localhost:3000/graphql';
 
+function authPlugin({ opContext }: { opContext: FetchOptions }) {
+  const token: string | null = localStorage.getItem(import.meta.env.VITE_TOKEN_KEY);
+  if (token) { opContext.headers.Authorization = `Bearer ${token}`; }
+}
+
 const client = createClient({
   url: host,
+  use: [authPlugin, ...defaultPlugins()],
 });
 
 export default client;

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -38,8 +38,9 @@ export const useUserStore = defineStore({
           this.onErrorLogin(code);
           return;
         }
-        const user: User | undefined = data?.user;
-        if (user) { this.user = user;  }
+        const { user, token }: { user?: User, token?: string } = data?.auth || {};
+        this.user = user;
+        if (token) { localStorage.setItem(import.meta.env.VITE_TOKEN_KEY, token); }
         return user;
       } catch (error) { console.error(error); }
       return;
@@ -56,6 +57,7 @@ export const useUserStore = defineStore({
     },
 
     doLogout() {
+      localStorage.removeItem(import.meta.env.VITE_TOKEN_KEY);
       googleLogout();
       this.user = undefined;
     },


### PR DESCRIPTION
## 🛠 주요 변경 사항 
- 서버 쪽이 token 을 사용하게끔 수정함에 따라 그에 맞게 수정하였습니다.
  - `signIn` mutation return 값 변경됨에 따라 반영
  - `token`을 `localStorage`에 넣어두고, Graphql 통신할 때마다 header 에 넣어서 통신하도록 수정  

<br/>

## 👩‍💻 Code Review 
- 💡 코드를 실행하기 전, 문서 `.env` 파일을 반영해주세요 ! 
- 💡 서버 PR(https://github.com/anniversaryArchive/archive-back/pull/36)이 머지되어있는 지 확인해주세요! 아직 머지되지 않았다면, 해당 브랜치(`/mod/user`)로 옮겨서 서버를 실행해주신 후, 테스트해주세요!

