### PR TITLE
CafeMap: Archive List Sorting

### DIFF
--- a/src/graphql/getArchives.query.gql
+++ b/src/graphql/getArchives.query.gql
@@ -1,5 +1,5 @@
-query ($page: Int, $perPage: Int, $filter: FilterOption, $start: Date, $end: Date, $sortOrder: Int) {
-  archive: ArchivePagination (page: $page, perPage: $perPage, filter: $filter, start: $start, end: $end, sortOrder: $sortOrder) {
+query ($page: Int, $perPage: Int, $filter: FilterOption, $start: Date, $end: Date, $sortOrder: Int, $sortField: String) {
+  archive: ArchivePagination (page: $page, perPage: $perPage, filter: $filter, start: $start, end: $end, sortOrder: $sortOrder, sortField: $sortField) {
     data {
       _id
       name

--- a/src/graphql/getArchives.query.gql
+++ b/src/graphql/getArchives.query.gql
@@ -1,5 +1,5 @@
-query ($page: Int, $perPage: Int, $filter: FilterOption, $start: Date, $end: Date) {
-  archive: ArchivePagination (page: $page, perPage: $perPage, filter: $filter, start: $start, end: $end) {
+query ($page: Int, $perPage: Int, $filter: FilterOption, $start: Date, $end: Date, $sortOrder: Int) {
+  archive: ArchivePagination (page: $page, perPage: $perPage, filter: $filter, start: $start, end: $end, sortOrder: $sortOrder) {
     data {
       _id
       name

--- a/src/pages/cafeMap.vue
+++ b/src/pages/cafeMap.vue
@@ -189,7 +189,7 @@ export default defineComponent({
         },
       };
       artistStore.getArtists(artistFilterData);
-      archiveStore.getArchives();
+      getArchives();
     };
 
     watch(() => artistStore.artists, async () => {
@@ -209,10 +209,7 @@ export default defineComponent({
     watch(() => archiveStore.archives, async () => {
       // 카페 목록 초기화 및 검색 버튼 이후에 할당
       if (!cscript.$isEmpty(artistList.value)) {
-        let archiveList = JSON.parse(JSON.stringify(archiveStore.archives));
-
-        // orderData 확인
-        archiveList = orderDataFunc(archiveList, orderData.value.value);
+        const archiveList = JSON.parse(JSON.stringify(archiveStore.archives));
         archiveParams.value = _.cloneDeep(archiveList);
 
         // 페이지네이션 설정
@@ -238,6 +235,23 @@ export default defineComponent({
       return true;
     }
 
+    // 현재 설정값에 맞춰 archiveStore.getArchives를 호출하여, 데이터를 가져오는 함수
+    function getArchives() {
+      const { schBeginDe, schEndDe } = archiveSchParams.value;
+
+      archiveStore.getArchives({
+        page: paginationData.value.current - 1,
+        perPage: paginationData.value.perPage,
+        filter: { flds: { artist: Array.from(artistList.value) } },
+        search: {
+          start: schBeginDe && moment(schBeginDe).format('YYYY-MM-DD'),
+          end: schEndDe && moment(schEndDe).format('YYYY-MM-DD')
+        },
+        sortOrder: orderData.value.value === 'newest' ? -1 : 1,
+        sortField: 'startDate',
+      });
+    }
+
     // 아카이브 검색
     async function searchBtnFunc() {
       // 검색 조건 확인
@@ -255,42 +269,7 @@ export default defineComponent({
       Object.entries(artistList.value).forEach(([, val]) => {
         artistListSave.push(val);
       });
-
-      const filterData = {
-        "flds": {
-          "artist" : artistListSave
-        }
-      }
-
-      const searchDate = {
-        "start": archiveSchParams.value.schBeginDe ? moment(archiveSchParams.value.schBeginDe).format('YYYY-MM-DD') : "",
-        "end": archiveSchParams.value.schEndDe ? moment(archiveSchParams.value.schEndDe).format('YYYY-MM-DD') : ""
-      }
-
-      // console.log('filterData : ', filterData);
-      archiveStore.getArchives(paginationData.value.current-1, paginationData.value.perPage, filterData, searchDate);
-    }
-
-    function orderDataFunc(list: any, key: string) {
-      switch (key) {
-        case 'newest': return descOrdSortDate(list);
-        case 'oldest': return ascOrdSortDate(list);
-        default: return list;
-      }
-    }
-
-    // 오름차순
-    function ascOrdSortDate(list : any) {
-      return list.sort(function (a: { startDate: string | number | Date; }, b: { startDate: string | number | Date; }) {
-        return new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
-      });
-    }
-
-    // 내림차순
-    function descOrdSortDate(list : any) {
-      return list.sort(function (a: { startDate: string | number | Date; }, b: { startDate: string | number | Date; }) {
-        return new Date(a.startDate).getTime() - new Date(b.startDate).getTime();
-      }).reverse();
+      getArchives();
     }
 
     function resetFunc() {
@@ -320,11 +299,10 @@ export default defineComponent({
       paginationData.value.maxCnt = null;
     }
 
+    // 정렬 방식 변경 시, 호출되는 함수
     function orderSelectChange() {
-      if(!cscript.$isEmpty(archiveParams.value)){
-        const changeData = orderDataFunc(archiveParams.value, orderData.value.value);
-        archiveParams.value = _.cloneDeep(changeData);
-      }
+      if (cscript.$isEmpty(archiveParams.value)) { return; }
+      getArchives();
     }
 
     function detailBtnFunc(id: string) {

--- a/src/stores/archive.ts
+++ b/src/stores/archive.ts
@@ -31,24 +31,35 @@ export const useArchiveStore = defineStore({
     group: undefined,
   }),
   getters: {
-    archives (): Archive[] { return this.data?.list || [] },
-    total (): number { return this.data?.total || 0 },
-    groupId (): string | undefined { return this.group?._id },
+    archives(): Archive[] { return this.data?.list || [] },
+    total(): number { return this.data?.total || 0 },
+    groupId(): string | undefined { return this.group?._id },
   },
   actions: {
-    setGroup (group: Group) {
+    setGroup(group: Group) {
       this.group = group;
     },
-    getArchive (id: string) {
+    getArchive(id: string) {
       return query(getArchive, { id }, false);
     },
-    getArchives (pageData? : number | null, perPageData? : number | null, filterData? : object, searchDate?: searchDate) {
+    getArchives(args: {
+      page?: number,
+      perPage?: number,
+      filter?: object,
+      search?: searchDate,
+      sortOrder?: number,
+      sortField?: string,
+    }) {
+      const { page, perPage, filter, search, sortOrder, sortField } = args;
+
       query(getArchives, {
-        page: pageData,
-        perPage : perPageData,
-        filter: filterData,
-        start: searchDate?.start,
-        end: searchDate?.end
+        page,
+        perPage,
+        filter,
+        sortOrder,
+        sortField,
+        start: search?.start,
+        end: search?.end,
       }, false).then(({ data, error, execute }) => {
         this.data = {
           list: computed(() => {
@@ -60,7 +71,7 @@ export const useArchiveStore = defineStore({
       });
     },
 
-    async createArchive (input: Record<string ,any>): Promise<{ id?: string, error: CombinedError | null } | undefined> {
+    async createArchive(input: Record<string, any>): Promise<{ id?: string, error: CombinedError | null } | undefined> {
       try {
         const { data, error } = await mutate(createArchive, { input });
         const id: string | undefined = data?.archive?._id;
@@ -70,7 +81,7 @@ export const useArchiveStore = defineStore({
       return;
     },
 
-    async updateArchive (id: string, input: Record<string, any>): Promise<boolean> {
+    async updateArchive(id: string, input: Record<string, any>): Promise<boolean> {
       try {
         const { data, error } = await mutate(updateArchive, { id, input });
         const success: boolean = data?.success || false;
@@ -80,7 +91,7 @@ export const useArchiveStore = defineStore({
       return false;
     },
 
-    async removeArchive (id: string): Promise<boolean> {
+    async removeArchive(id: string): Promise<boolean> {
       try {
         const { data, error } = await mutate(removeArchive, { id });
         const success: boolean = data?.success || false;


### PR DESCRIPTION
### 이전
서버 호출 없이 가져온 Archive 리스트 내에서 Sorting을 진행

### 문제점 
Archive는 Pagination 으로 되어있기 때문에, 정렬 방식이 달라지면 현재 page에 따라 가져오는 Archive 리스트 자체가 달라진다.
따라서 sorting 방식이 딸라지면 `ArchivePagination` query를 다시 호출해야 한다.

### 변경된 점
따라서 `cafeMap.vue`에서 **정렬 방식**이 달라질 때마다 `getArchvies`를 호출하도록 변경하였다. 

1. archiveStore 의 `getArchives` function 이 arguments 를 object 형식으로 변경.
2. cafeMap.vue 에 `getArchvies` function을 생성하여, archive list를 가져올 때 공통적으로 사용할 수 있도록 함.

![화면-기록-2023-08-12-오후-5 03 27 (1)](https://github.com/anniversaryArchive/archive/assets/31975198/29466e07-eb3d-4683-b992-4980589d00b0)
