### PR TITLE
GraphQL - store Pagination 로직

### DIFF
--- a/src/pages/Admin/Archive.vue
+++ b/src/pages/Admin/Archive.vue
@@ -68,7 +68,7 @@
           <tr>
             <th>카페 종료일</th>
             <td colspan="3">
-              <DatePicker :ref='el => { refs["endDate"] = el }' :id="inputArchive.endDate" 
+              <DatePicker :ref='el => { refs["endDate"] = el }' :id="inputArchive.endDate"
                 v-model='inputArchive.endDate' :clearable='true' returnDataFormat="YYYY.MM.DD" />
             </td>
           </tr>
@@ -290,7 +290,7 @@ async function getGroups () {
 function setInputArchive(value: Archive) {
   value.mainImage = value.mainImage;
   for (const key of ['startDate', 'endDate']) {
-    if (value[key]) { 
+    if (value[key]) {
       value[key] = moment(value[key]).format('YYYY.MM.DD');
     }
   }
@@ -305,7 +305,7 @@ function setInputArchive(value: Archive) {
 /**
  * Input Box 내 Action 관련 함수
  */
-// 주소 찾기 버튼 클릭 시 
+// 주소 찾기 버튼 클릭 시
 function onClickFindAddressButton () {
   isOpenFindAddressDialog.value = true;
 }
@@ -321,7 +321,7 @@ function onChangeTimeCheckbox (type: string, event) {
 
 /**
  * =================================
- * 상단 버튼(Action) 관련 Functions .. 
+ * 상단 버튼(Action) 관련 Functions ..
  * =================================
  */
 const fnCallFunc = (id: string) => {
@@ -359,7 +359,7 @@ async function fnInquire() {
     const checked: boolean = await confirmDiffData();
     if (!checked) { return; }
   } catch (error) { console.error(error); }
-  archiveStroe.getArchives();
+  archiveStroe.getArchives({});
 }
 
 /**
@@ -376,7 +376,7 @@ async function checkDiffData(): Promise<boolean> {
   // 그룹이 변경되었는 지 여부
   const groupDiff = archiveGroup.value?.id !== inputArchiveOrg.value.group?._id;
 
-  // 이미지가 변경됐는 지 확인 
+  // 이미지가 변경됐는 지 확인
   const imageDiff = (inputArchive.value.mainImage?._id || inputArchive.value.mainImage?.name) !== (inputArchiveOrg.value.mainImage?._id || inputArchiveOrg.value.mainImage?.name);
 
   const images = inputArchive.value.images.map(image => image.path);
@@ -406,13 +406,13 @@ async function checkDiffData(): Promise<boolean> {
 // 필수 입력 항목 체크 - 생일, 이미지, 이름
 function isMstValid(): boolean {
   const requireFields = [
-    { key: 'name', text: '카페 이름' }, 
-    { key: 'themeName', text: '카페 테마 명' }, 
-    { key: 'address', text: '주소' }, 
-    { key: 'organizer', text: '주최자' }, 
-    { key: 'startDate', text: '카페 시작일' }, 
-    { key: 'endDate', text: '카페 종료일' }, 
-    { key: 'mainImage', text: '메인 이미지' }, 
+    { key: 'name', text: '카페 이름' },
+    { key: 'themeName', text: '카페 테마 명' },
+    { key: 'address', text: '주소' },
+    { key: 'organizer', text: '주최자' },
+    { key: 'startDate', text: '카페 시작일' },
+    { key: 'endDate', text: '카페 종료일' },
+    { key: 'mainImage', text: '메인 이미지' },
   ];
 
   for (const field of requireFields) {
@@ -425,7 +425,7 @@ function isMstValid(): boolean {
   return true;
 }
 
-// 저장 버튼 클릭 시 
+// 저장 버튼 클릭 시
 async function onClickSaveBtn() {
   if (inputArchive.value._id) {
     try {
@@ -548,7 +548,7 @@ async function updateArchive(): Promise<boolean> {
 // 선택한 Archive를 반환하는 함수, 없으면 undefined를 반환한다.
 function getSelectedArchive (required: boolean = false): Archive | undefined {
   const selectedRows = grdApi.value.getSelectedRows();
-  // 선택한 아티스트가 없는 경우 
+  // 선택한 아티스트가 없는 경우
   if (!selectedRows.length) {
     if (required) { alert('아티스트를 선택해주세요!'); }
     return;
@@ -634,10 +634,10 @@ async function uploadImages(): Promise<boolean> {
 
 /**
  * =================================
- * Grid 관련 변수 및 Functions .. 
+ * Grid 관련 변수 및 Functions ..
  * =================================
  */
-// 변경사항 체크 
+// 변경사항 체크
 async function confirmDiffData(): Promise<boolean> {
   try {
     const diff = await checkDiffData();
@@ -647,14 +647,14 @@ async function confirmDiffData(): Promise<boolean> {
   return true;
 }
 
-// Grid Cell 포커스 
+// Grid Cell 포커스
 async function onCellFocused(event: CellFocusedEvent) {
   // 포커스 셀 변경 시 해당 셀의 행 선택
   const focusNode = grdApi.value.getRenderedNodes().find((node: RowNode) => {
     return node.childIndex === event.rowIndex;
   });
 
-  // 변경사항 체크 
+  // 변경사항 체크
   try {
     const confirm: boolean = await confirmDiffData();
     if (!confirm) { return; }

--- a/src/pages/favorite.vue
+++ b/src/pages/favorite.vue
@@ -127,8 +127,8 @@ export default defineComponent({
         clearable: true,
         style    : 'width: 250px',
       };
-      if(favoriteGroupsList.FavoriteGroupList){
-        selectBoxOptions.value.group.data = await cscript.$getComboOptions(favoriteGroupsList.FavoriteGroupList);
+      if(favoriteGroupsList){
+        selectBoxOptions.value.group.data = await cscript.$getComboOptions(favoriteGroupsList);
       }
 
       //초기값 셋팅

--- a/src/stores/archive.ts
+++ b/src/stores/archive.ts
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
-import { computed } from 'vue';
+import { CombinedError, BaseQueryApi } from 'villus';
 import { WatchQuery } from '@/types/CommonTypes';
 import { Archive } from '@/types/Archive'
 import { Group } from '@/types/Group';
 import { query, mutate } from '@/composables/graphqlUtils';
-import { CombinedError } from 'villus';
+import { parsePaginationData } from './functions';
 
 import getArchive from '@/graphql/getArchive.query.gql';
 import getArchives from '@/graphql/getArchives.query.gql';
@@ -36,6 +36,9 @@ export const useArchiveStore = defineStore({
     groupId(): string | undefined { return this.group?._id },
   },
   actions: {
+    setArchives(result: BaseQueryApi<any, object>) {
+      this.data = parsePaginationData.call(this, 'archive', result);
+    },
     setGroup(group: Group) {
       this.group = group;
     },
@@ -60,22 +63,14 @@ export const useArchiveStore = defineStore({
         sortField,
         start: search?.start,
         end: search?.end,
-      }, false).then(({ data, error, execute }) => {
-        this.data = {
-          list: computed(() => {
-            return data.value?.archive?.data || [];
-          }),
-          total: computed(() => { return data.value?.archive?.total || 0; }),
-          fetch: execute,
-        };
-      });
+      }, false).then(this.setArchives);
     },
 
     async createArchive(input: Record<string, any>): Promise<{ id?: string, error: CombinedError | null } | undefined> {
       try {
         const { data, error } = await mutate(createArchive, { input });
         const id: string | undefined = data?.archive?._id;
-        if (id) { this.data?.fetch(); }
+        if (id) { this.setArchives(await this.data?.fetch()); }
         return { id, error };
       } catch (error) { console.error(error); }
       return;
@@ -83,9 +78,9 @@ export const useArchiveStore = defineStore({
 
     async updateArchive(id: string, input: Record<string, any>): Promise<boolean> {
       try {
-        const { data, error } = await mutate(updateArchive, { id, input });
+        const { data } = await mutate(updateArchive, { id, input });
         const success: boolean = data?.success || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setArchives(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;
@@ -93,9 +88,9 @@ export const useArchiveStore = defineStore({
 
     async removeArchive(id: string): Promise<boolean> {
       try {
-        const { data, error } = await mutate(removeArchive, { id });
+        const { data } = await mutate(removeArchive, { id });
         const success: boolean = data?.success || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setArchives(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;

--- a/src/stores/artist.ts
+++ b/src/stores/artist.ts
@@ -1,8 +1,9 @@
-import { computed } from 'vue';
 import { defineStore } from 'pinia';
+import { BaseQueryApi } from 'villus';
 import { Artist } from '@/types/Artist';
 import { WatchQuery } from '@/types/CommonTypes';
 import { query, mutate } from '@/composables/graphqlUtils';
+import { parsePaginationData } from './functions';
 
 import getArtists from '@/graphql/getArtists.query.gql';
 import createArtist from '@/graphql/createArtist.mutate.gql';
@@ -15,42 +16,37 @@ interface ArtistState {
 
 export const useArtistStore = defineStore({
   id: 'artist',
-  state : (): ArtistState => ({ data: undefined }),
+  state: (): ArtistState => ({ data: undefined }),
   getters: {
-    artists (): Artist[] { return this.data?.list || [] },
-    total (): number { return this.data?.total || 0 },
+    artists(): Artist[] { return this.data?.list || [] },
+    total(): number { return this.data?.total || 0 },
   },
   actions: {
-    getArtists (filterData? : object) {
-      query(getArtists, { filter: filterData }, false).then(({ data, error, execute }) => {
-        this.data = {
-          list: computed(() => {
-            return data.value?.artist?.data || [];
-          }),
-          total: computed(() => { return data.value?.artist?.total || 0; }),
-          fetch: execute,
-        };
-      });
+    setArtists(result: BaseQueryApi<any, object>) {
+      this.data = parsePaginationData.call(this, 'artist', result);
+    },
+    getArtists(filterData?: object) {
+      query(getArtists, { filter: filterData }, false).then(this.setArtists);
     },
 
-    getArtistsQuery (variables: Record<string, any> = {}) {
+    getArtistsQuery(variables: Record<string, any> = {}) {
       return query(getArtists, variables, false);
     },
 
     async createArtist(input: Record<string, any>): Promise<string | undefined> {
       try {
-        const { data, error } = await mutate(createArtist, { input });
+        const { data } = await mutate(createArtist, { input });
         const id: string | undefined = data?.artist?._id;
-        if (id) { this.data?.fetch(); }
+        if (id) { this.setArtists(await this.data?.fetch()); }
         return id;
       } catch (_) { return; }
     },
 
     async updateArtist(id: string, input: Record<string, any>): Promise<boolean> {
       try {
-        const { data, error } = await mutate(patchArtist, { id, input });
+        const { data } = await mutate(patchArtist, { id, input });
         const success: boolean = data?.success || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setArtists(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;
@@ -58,9 +54,9 @@ export const useArtistStore = defineStore({
 
     async removeArtist(id: string): Promise<boolean> {
       try {
-        const { data, error } = await mutate(removeArtist, { id });
+        const { data } = await mutate(removeArtist, { id });
         const success: boolean = data?.success || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setArtists(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;

--- a/src/stores/favoriteGroup.ts
+++ b/src/stores/favoriteGroup.ts
@@ -1,33 +1,22 @@
 import { defineStore } from 'pinia';
-import {query} from '@/composables/graphqlUtils';
-import {computed} from 'vue';
-import {FavoriteGroup} from '@/types/Favorite';
+import { query } from '@/composables/graphqlUtils';
+import { FavoriteGroup } from '@/types/Favorite';
 import getFavoritesGroup from '@/graphql/getFavoritesGroup.query.gql';
-import {WatchQuery} from '@/types/CommonTypes';
 
 interface FavoriteState {
-  data?: WatchQuery<FavoriteGroup>;
+  favoriteGroups: FavoriteGroup[];
 }
 
 export const useFavoriteGroupStore = defineStore({
   id: 'favoriteGroup',
-  state: (): FavoriteState => ({ data: undefined }),
+  state: (): FavoriteState => ({ favoriteGroups: [] }),
   getters: {
-    favoriteGroups (): FavoriteGroup[] { return this.data?.list || [] },
-    total (): number { return this.data?.total || 0 },
+    total(): number { return this.data?.total || 0 },
   },
   actions: {
     getFavoriteGroupState() {
-      query(getFavoritesGroup, {}, false).then(({ data, error, execute }) => {
-        this.data = {
-          list: computed(() => {
-            // 전달 데이터 확인 후 수정
-            return data.value || [];
-          }),
-          // 전달 데이터 확인 후 수정
-          total: computed(() => { return data.value || 0; }),
-          fetch: execute,
-        }
+      query(getFavoritesGroup, {}, false).then(({ data }) => {
+        this.favoriteGroups = data.value?.FavoriteGroupList || [];
       });
     }
   }

--- a/src/stores/functions.ts
+++ b/src/stores/functions.ts
@@ -1,0 +1,14 @@
+import { BaseQueryApi } from 'villus';
+import { WatchQuery } from '@/types/CommonTypes';
+
+export function parsePaginationData<T>(type: string, { data, execute }: BaseQueryApi<any, object>): WatchQuery<T> | undefined {
+  arguments
+  data = data.value || data;
+  if (!data) { return data; }
+  const result = data[type] || {};
+  return {
+    list: result.data || [],
+    total: result.total || 0,
+    fetch: execute || this.data.fetch,
+  };
+}

--- a/src/stores/group.ts
+++ b/src/stores/group.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia';
-import { QueryExecutionOpts } from 'villus';
-import {Group} from '@/types/Group';
-import {mutate, query} from '@/composables/graphqlUtils';
-import {computed, ComputedRef} from 'vue';
-import {ToSaveData} from '@/types/CommonTypes';
+import { BaseQueryApi } from 'villus';
+import { Group } from '@/types/Group';
+import { mutate, query } from '@/composables/graphqlUtils';
+import { WatchQuery, ToSaveData } from '@/types/CommonTypes';
+import { parsePaginationData } from './functions';
 
 import getGroups from '@/graphql/getGroups.query.gql';
 import removeGroup from '@/graphql/removeGroup.mutate.gql';
@@ -11,40 +11,26 @@ import createGroup from '@/graphql/createGroup.mutate.gql';
 import updateGroup from '@/graphql/updateGroup.mutate.gql';
 
 
-interface FetchFunc {
-  (overrideOpts?: Partial<QueryExecutionOpts<any>>): Promise<any>
-}
-
-interface WatchQuery {
-  list: Group[];
-  total: ComputedRef<number>;
-  fetch: FetchFunc;
-}
-
 interface GroupState {
-  data?: WatchQuery;
+  data?: WatchQuery<Group>;
 }
 
 export const useGroupStore = defineStore({
   id: 'group',
-  state : (): GroupState => ({ data: undefined }),
+  state: (): GroupState => ({ data: undefined }),
   getters: {
-    groups (): Group[] { return this.data?.list || [] },
-    total (): number { return this.data?.total || 0 },
+    groups(): Group[] { return this.data?.list || [] },
+    total(): number { return this.data?.total || 0 },
   },
   actions: {
-    getGroups () {
-      query(getGroups, {}, false).then(({ data, error, execute }) => {
-        this.data = {
-          list: computed(() => {
-            return data.value?.groups?.data || [];
-          }),
-          total: computed(() => { return data.value?.groups?.total || 0; }),
-          fetch: execute,
-        };
-      });
+    setGroups(result: BaseQueryApi<any, object>) {
+      this.data = parsePaginationData.call(this, 'groups', result);
     },
-    getGroupsQuery (variables: Record<string, any>) {
+
+    getGroups() {
+      query(getGroups, {}, false).then(this.setGroups);
+    },
+    getGroupsQuery(variables: Record<string, any>) {
       return query(getGroups, variables);
     },
 
@@ -52,7 +38,7 @@ export const useGroupStore = defineStore({
       try {
         const { data } = await mutate(removeGroup, { id });
         const success: boolean = data?.success || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setGroups(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;
@@ -60,9 +46,9 @@ export const useGroupStore = defineStore({
 
     async createGroup(saveData: ToSaveData): Promise<boolean> {
       try {
-        const { data } = await mutate(createGroup, {saveData});
+        const { data } = await mutate(createGroup, { saveData });
         const success: boolean = data?.createGroup._id || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setGroups(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;
@@ -70,9 +56,9 @@ export const useGroupStore = defineStore({
 
     async updateGroup(updateGroupId: unknown, saveData: ToSaveData): Promise<boolean> {
       try {
-        const { data } = await mutate(updateGroup, {updateGroupId, saveData});
+        const { data } = await mutate(updateGroup, { updateGroupId, saveData });
         const success: boolean = data?.updateGroup || false;
-        if (success) { this.data?.fetch(); }
+        if (success) { this.setGroups(await this.data?.fetch()); }
         return success;
       } catch (error) { console.error(error); }
       return false;

--- a/src/types/CommonTypes.ts
+++ b/src/types/CommonTypes.ts
@@ -1,5 +1,5 @@
-import {GridOptions} from '@ag-grid-community/core';
-import {AllCommunityModules} from '@ag-grid-community/all-modules';
+import { GridOptions } from '@ag-grid-community/core';
+import { AllCommunityModules } from '@ag-grid-community/all-modules';
 import { QueryExecutionOpts } from 'villus';
 import { ComputedRef } from 'vue';
 
@@ -101,14 +101,14 @@ export interface FetchFunc {
 }
 
 export interface WatchQuery<T> {
-    list: ComputedRef<T[]>;
-    total: ComputedRef<number>;
+    list: T[];
+    total: number;
     fetch: FetchFunc;
 }
 
 export interface Variables {
-    perPage     : number,
-    page        : number,
-    sortOrder?  : number,
-    group?      : string
+    perPage: number,
+    page: number,
+    sortOrder?: number,
+    group?: string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,14 +9,29 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "lib": ["ESNext", "DOM"],
+    "noImplicitThis": false,
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
     "skipLibCheck": true,
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": [
+        "src/*"
+      ]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }


### PR DESCRIPTION
### 발견한 문제
기존 store 내에서 `WatchQuery`를 활용하여 데이터를 저장하는 부분에 있어서, 정의해놓은 타입과 저장되는 타입이 일치하지 않은 문제를 발견했습니다. 해당 부분을 고치기 위하여 전체적으로 수정하였습니다.

### 변경 사항
- query를 get했을 때와 `execute`를 호출했을 때마다, 데이터를 새로 저장하게끔 구현하였습니다. 
- 저장할 때마다 `parsePaginationData` function 을 호출하므로, 해당 함수를 참고하시면 됩니다.