### PR TITLE
즐겨찾기 화면 : 기능 추가

### DIFF
--- a/src/components/CafeItem.vue
+++ b/src/components/CafeItem.vue
@@ -24,6 +24,7 @@ import { useUserStore } from '@/stores/user';
 
 import createFavorite from '@/graphql/createFavorite.mutate.gql';
 import removeFavorite from '@/graphql/removeFavorite.mutate.gql';
+import {useFavoriteArchiveStore} from '@/stores/favoriteArchive';
 
 interface Props {
   archive: Archive;
@@ -34,6 +35,7 @@ const emit = defineEmits(['click']);
 
 const $q = useQuasar();
 const userStore = useUserStore();
+const favoriteArchiveStore = useFavoriteArchiveStore();
 const archive: ComputedRef<Archive> = computed(() => props.archive);
 
 // 카페 아이템 클릭 시
@@ -49,34 +51,16 @@ async function onClickFavoriteIcon() {
     return;
   }
 
-  let success: boolean = false;
+  let success: any = false;
   try {
     if (archive.value.favorite) {
-      success = await doRemoveFavorite();
+      success = favoriteArchiveStore.doRemoveFavorite(archive.value._id);
     } else {
-      success = await doCreateFavorite();
+      success = favoriteArchiveStore.doCreateFavorite(archive.value._id);
     }
     if (!success) { return; }
     props.archive.favorite = !props.archive.favorite;
   } catch (_) {}
-}
-
-// 즐겨찾기 추가
-async function doCreateFavorite(): Promise<boolean> {
-  try {
-    const { data } = await mutate(createFavorite, { archive: archive.value._id });
-    return !!data.favorite?._id;
-  } catch (_) {}
-  return false;
-}
-
-// 즐겨찾기 제거
-async function doRemoveFavorite(): Promise<boolean> {
-  try {
-    const { data } = await mutate(removeFavorite, { archive: archive.value._id });
-    return data.success && true;
-  } catch (_) {}
-  return false;
 }
 </script>
 

--- a/src/graphql/getFavoriteArchives.query.gql
+++ b/src/graphql/getFavoriteArchives.query.gql
@@ -19,5 +19,6 @@ query FavoritePagination($sortOrder: Int, $page: Int, $perPage: Int, $group: ID,
         }
       }
     }
+    total
   }
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -3,7 +3,7 @@
     <LayoutHeader />
     <q-page-container class="pt-14">
       <q-page>
-        <div id="troublemaker" class="bg-[#DDF1FF] h-screen mt-[-3.5rem] pt-14">
+        <div id="troublemaker" class="bg-[#fff] h-screen mt-[-3.5rem] pt-14">
           <slot />
         </div>
       </q-page>

--- a/src/pages/favorite.vue
+++ b/src/pages/favorite.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div class="flex flex-col justify-center h-full">
     <div class="row bg-div">
-      <q-card class="my-card info-card col-4 mr-12" color="white">
+      <q-card class="my-card info-card col-3 mr-12" color="white">
         <q-card-section>
           <ul>
             <li class="card-title pb-3">프로필 정보</li>
@@ -36,7 +36,7 @@
         </q-card-section>
       </q-card>
 
-      <q-card class="my-card favorite-card col-7" color="white">
+      <q-card class="my-card favorite-card col-8" color="white">
         <q-card-section>
           <ul class="row">
             <li class="card-title col-10">
@@ -63,13 +63,23 @@
             </li>
           </ul>
         </q-card-section>
+
+        <footer>
+          <div class="pagination justify-center mt-4 row q-mt-md q-mb-md">
+            <q-pagination
+              v-model="paginationData.current"
+              direction-links
+              :max="maxPage"
+              @update:model-value="onChangePage" />
+          </div>
+        </footer>
       </q-card>
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeMount, ref, Ref, watch} from 'vue';
+import {computed, ComputedRef, defineComponent, onBeforeMount, ref, Ref, watch} from 'vue';
 import mixinPageCommon from "@/pages/mixin/mixinPageCommon"
 import {Archive, ArchiveSearchParams} from '@/types/Archive';
 import cscript from "@/composables/comScripts"
@@ -89,7 +99,6 @@ export default defineComponent({
   components: {},
   mixins: [mixinPageCommon],
   setup() {
-    //const $q = useQuasar()
     const archiveParams: Ref<FavoriteArchive[]> = ref([])
 
     const groupList = ref([] as string[])
@@ -113,10 +122,14 @@ export default defineComponent({
       'value': 'newest',
     });
 
+    // pagination 관련 변수
     const paginationData = ref({
       current: 1,
       perPage: 10,
     } as Pagination);
+    const total: Ref<number> = ref(0);
+    const perPage: number = 10;
+    const maxPage: ComputedRef<number> = computed(() => Math.ceil(total.value / perPage));
 
     onBeforeMount(() => {
       initialize();
@@ -295,6 +308,11 @@ export default defineComponent({
       return false;
     }
 
+    // 페이지 변경 시
+    function onChangePage() {
+      searchData();
+    }
+
     return {
       groupList,
       archiveParams,
@@ -302,14 +320,24 @@ export default defineComponent({
       selectBoxOptions,
       orderData,
       orderOptions,
+      paginationData,
+      maxPage,
       resetFunc,
       detailBtnFunc,
       searchBtnFunc,
       orderSelectChange,
-      onClickFavoriteIcon
+      onClickFavoriteIcon,
+      onChangePage
     }
   }
 })
 </script>
 
-<style scoped></style>
+<style scoped>
+footer .pagination {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/src/pages/favorite.vue
+++ b/src/pages/favorite.vue
@@ -156,8 +156,8 @@ export default defineComponent({
       archiveList = orderDataFunc(archiveList, orderData.value.value);
       archiveParams.value = _.cloneDeep(archiveList);
 
-      // 페이지네이션 설정 total
-      total.value = archiveList.length;
+      // 페이지네이션 설정 : total
+      total.value = favoriteArchiveStore.total;
     });
 
     function resetFunc() {
@@ -273,9 +273,9 @@ export default defineComponent({
       let success: any = false;
       try {
         if(item.favorite && item._id) {
-          success = favoriteArchiveStore.doRemoveFavorite(item._id);
+          success = await favoriteArchiveStore.doRemoveFavorite(item._id);
         }else if(item._id) {
-          success = favoriteArchiveStore.doCreateFavorite(item._id);
+          success = await favoriteArchiveStore.doCreateFavorite(item._id);
         }
 
         if(!success) { return; }

--- a/src/pages/favorite.vue
+++ b/src/pages/favorite.vue
@@ -1,13 +1,8 @@
 <template>
-  <div class="flex flex-col justify-center h-full">
+  <div class="xl-flex flex-col justify-center h-full">
     <div class="row bg-div">
-      <q-card class="my-card info-card col-3 mr-12" color="white">
+      <q-card class="my-card info-card col-xl-3 col-xs-12" color="white">
         <q-card-section>
-          <ul>
-            <li class="card-title pb-3">프로필 정보</li>
-            <li class="info-text pb-5">닉네임</li>
-          </ul>
-
           <div>
             <h1 class="search-text">그룹 선택</h1>
             <select-box
@@ -36,18 +31,18 @@
         </q-card-section>
       </q-card>
 
-      <q-card class="my-card favorite-card col-8" color="white">
-        <q-card-section>
-          <ul class="row">
-            <li class="card-title col-10">
-              즐겨찾기
-            </li>
-            <li class="card-title col-2">
-              <q-select class="order-select" v-model="orderData" :options="orderOptions"
-                        @update:model-value="orderSelectChange()" borderless ></q-select>
-            </li>
-          </ul>
+      <q-card class="my-card favorite-card col-xl-8 col-xs-12" color="white">
+        <ul class="row">
+          <li class="card-title col-xl-10 col-xs-8">
+            즐겨찾기
+          </li>
+          <li class="card-title col-xl-2 col-xs-4">
+            <q-select class="order-select" v-model="orderData" :options="orderOptions"
+                      @update:model-value="orderSelectChange()" borderless ></q-select>
+          </li>
+        </ul>
 
+        <q-card-section class="q-card-box">
           <ul v-for="(item) in archiveParams" v-bind:key="item._id" class="favor-list row">
             <li class="col-2">{{item.archive.group?.name}}</li>
             <li class="col-2">{{item.archive.artist?.name}}</li>
@@ -93,6 +88,7 @@ import _ from 'lodash';
 import {mutate} from '@/composables/graphqlUtils';
 import createFavorite from '@/graphql/createFavorite.mutate.gql';
 import removeFavorite from '@/graphql/removeFavorite.mutate.gql';
+import {useUserStore} from '@/stores/user';
 
 export default defineComponent({
   name: "favorite",
@@ -100,12 +96,12 @@ export default defineComponent({
   mixins: [mixinPageCommon],
   setup() {
     const archiveParams: Ref<FavoriteArchive[]> = ref([])
-
     const groupList = ref([] as string[])
 
     const {selectBoxOptions: selectBoxOptions} = ccobject.$createSelectAll(["group"]);
     const {schParams: archiveSchParams} = ccobject.$createSchParams<ArchiveSearchParams>();
 
+    const userStore = useUserStore();
     const favoriteGroupsStore = useFavoriteGroupStore();
     const favoriteArchiveStore = useFavoriteArchiveStore();
 
@@ -116,7 +112,6 @@ export default defineComponent({
       'label': '오래된순',
       'value': 'oldest',
     }];
-
     const orderData = ref({
       'label': '최신순',
       'value': 'newest',
@@ -334,10 +329,40 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.xl-flex {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 footer .pagination {
   position: absolute;
   bottom: 0;
   left: 50%;
   transform: translate(-50%, -50%);
+}
+
+/* 모바일 화면 */
+@media screen and (max-width: 767px) {
+  .xl-flex {
+    display: block;
+    flex-wrap: nowrap;
+  }
+
+  footer .pagination {
+    position: relative;
+    margin-bottom: 0;
+  }
+
+  .q-card-box {
+    padding: 0 0 10px;
+  }
+
+  .favor-list {
+    padding: 10px;
+  }
+
+  .favor-list li {
+    font-size: 12px;
+  }
 }
 </style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -37,7 +37,7 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import("@/pages/ArchiveDetail.vue")
   },
   {
-    meta: { title: "favorite" },
+    meta: { title: "favorite", layout: "MainLayout"},
     path: "/favorite",
     beforeEnter: authUser,
     component: () => import("@/pages/favorite.vue")

--- a/src/stores/favoriteArchive.ts
+++ b/src/stores/favoriteArchive.ts
@@ -1,10 +1,12 @@
 import { defineStore } from 'pinia';
 import { BaseQueryApi } from 'villus';
-import { query } from '@/composables/graphqlUtils';
+import {mutate, query} from '@/composables/graphqlUtils';
 import { FavoriteArchive } from '@/types/Favorite';
 import getFavoriteArchives from '@/graphql/getFavoriteArchives.query.gql';
 import { Variables, WatchQuery } from '@/types/CommonTypes';
 import { parsePaginationData } from './functions';
+import createFavorite from '@/graphql/createFavorite.mutate.gql';
+import removeFavorite from '@/graphql/removeFavorite.mutate.gql';
 
 interface FavoriteState {
   data?: WatchQuery<FavoriteArchive>;
@@ -34,6 +36,20 @@ export const useFavoriteArchiveStore = defineStore({
         start: searchDate?.start,
         end: searchDate?.end
       }, false).then(this.setFavoriteArchives);
+    },
+    async doCreateFavorite(_id: string): Promise<boolean> {
+      try {
+        const { data } = await mutate(createFavorite, { archive: _id });
+        return !!data.favorite?._id;
+      } catch (_) {}
+      return false;
+    },
+    async doRemoveFavorite(_id: string): Promise<boolean> {
+      try {
+        const { data } = await mutate(removeFavorite, { archive: _id });
+        return data.success && true;
+      } catch (_) {}
+      return false;
     }
   }
 });

--- a/src/style.css
+++ b/src/style.css
@@ -157,6 +157,10 @@ body {
   justify-content: center;
 }
 
+.info-card {
+  margin-right: 20px;
+}
+
 .info-card,
 .favorite-card {
   padding: 20px;
@@ -297,4 +301,15 @@ body {
     line-height: 0;
   }
   /* End ArchiveDetail.vue */
+
+  /* favorite.vue */
+  .bg-div {
+    padding: 0;
+  }
+
+  .info-card {
+    margin-right: 0;
+    margin-bottom: 20px;
+  }
+  /* End favorite.vue */
 }

--- a/src/style.css
+++ b/src/style.css
@@ -153,7 +153,7 @@ body {
 /* favorite.vue */
 .bg-div {
   /*background: #ddf1ff;*/
-  padding: 64px 200px;
+  padding: 0 200px;
   justify-content: center;
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -153,7 +153,8 @@ body {
 /* favorite.vue */
 .bg-div {
   /*background: #ddf1ff;*/
-  padding: 64px 210px;
+  padding: 64px 200px;
+  justify-content: center;
 }
 
 .info-card,

--- a/src/types/Archive.ts
+++ b/src/types/Archive.ts
@@ -3,7 +3,7 @@ import { Image } from './Image';
 
 export interface Archive {
   [key: string]: any;
-  _id?: string,           // 카페 ID
+  _id: string,           // 카페 ID
   name: string;           // 카페 이름
   themeName: string;      // 카페 테마 명
   address: string;        // 주소


### PR DESCRIPTION
## 🛠 주요 변경 사항 
1. 카페 목록
    - 즐겨찾기 아이콘 추가
    - 페이지네이션 추가
   
2. 기타
    - 모바일 화면 CSS 추가
      → 모바일 화면에서 깨지지 않을 정도로만 수정하였습니다.
    
※ 배경색은 일단 흰색으로 변경 해두었습니다.
디자인은 기능 추가 후 전체적으로 수정 해야 할 것 같습니다.

## 💻 구현 화면 : PC
![즐겨찾기_P](https://github.com/anniversaryArchive/archive/assets/68046496/b36763e7-c159-497e-9d4b-9a5535da70d3)

## 📱 구현 화면 : Mobile
<img width="365" alt="즐겨찾기_M" src="https://github.com/anniversaryArchive/archive/assets/68046496/65ed1418-4caf-4348-9e40-8d7a1f6d82a9">
