### PR TITLE
소통창구(CommunicationBoard) 기능 추가

### DIFF
--- a/src/composables/addressUtils.ts
+++ b/src/composables/addressUtils.ts
@@ -1,0 +1,11 @@
+export function getLatLng(address: string): Promise<Record<string, number>> {
+  return new Promise((resolve, reject) => {
+    naver.maps.Service.geocode({
+      query: address
+    }, function (status, response) {
+      const data = response.v2.addresses[0];
+      const { x, y } = data;
+      resolve({ lng: Number(x), lat: Number(y) });
+    });
+  });
+}

--- a/src/graphql/acceptCommunicationBoard.mutate.gql
+++ b/src/graphql/acceptCommunicationBoard.mutate.gql
@@ -1,0 +1,3 @@
+mutation ($id: ID!, $message: String) {
+    success: acceptCommunicationBoard (id: $id, message: $message)
+}

--- a/src/graphql/reRequestCommunicationBoard.mutate.gql
+++ b/src/graphql/reRequestCommunicationBoard.mutate.gql
@@ -1,0 +1,3 @@
+mutation ($id: ID!) {
+  success: reRequestCommunicationBoard (id: $id)
+}

--- a/src/graphql/rejectCommunicationBoard.mutate.gql
+++ b/src/graphql/rejectCommunicationBoard.mutate.gql
@@ -1,0 +1,3 @@
+mutation ($id: ID!, $message: String!) {
+    success: rejectCommunicationBoard (id: $id, message: $message)
+}

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -19,7 +19,6 @@
           :class="{ 'text-primary': currentPath === menu.to }">
           {{ menu.label }}
         </router-link>
-        {{current}}
       </q-scroll-area>
     </q-drawer>
 

--- a/src/pages/Admin/Archive.vue
+++ b/src/pages/Admin/Archive.vue
@@ -216,6 +216,7 @@ import ccobject from '@/composables/createComObject';
 import cinitial from '@/composables/comInitialize';
 import cscript from '@/composables/comScripts';
 import caggrid, { DateFormatter } from '@/composables/customAgGridUtils';
+import { getLatLng } from '@/composables/addressUtils';
 
 // Components
 import { LayoutPageTitle, DatePicker, SelectBox, AgGridVue } from '../mixin/mixinPageCommon';
@@ -476,17 +477,6 @@ async function onClickSaveBtn() {
   alert('저장 완료했습니다!');
 }
 
-function getLatLng(): Promise<Record<string, number>> {
-  return new Promise((resolve, reject) => {
-    naver.maps.Service.geocode({
-      query: inputArchive.value.address
-    }, function (status, response) {
-      const data = response.v2.addresses[0];
-      const { x, y } = data;
-      resolve({ lng: Number(x), lat: Number(y) });
-    });
-  });
-}
 
 // 생성 / 수정 시 mutation에 넘길 input을 만들어서 반환하는 함수
 async function getInput(): Promise<Record<string, any> | undefined> {
@@ -516,7 +506,7 @@ async function getInput(): Promise<Record<string, any> | undefined> {
 
   if (inputArchive.value.address !== inputArchiveOrg.value.address) {
     try {
-      const { lat, lng } = await getLatLng();
+      const { lat, lng } = await getLatLng(inputArchive.value.address);
       input.lat = inputArchive.value.lat = lat;
       input.lng = inputArchive.value.lng = lng;
     } catch (_) {}

--- a/src/pages/CommunicationBoard/CommunicationBoard.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoard.vue
@@ -14,7 +14,7 @@
         </div>
 
         <!-- 내 글 보기 / 전체 글 보기 -->
-        <div>
+        <div v-if="loggedIn" class="flex flex-col justify-center">
           <button class="px-4 py-1 border border-gray-400 rounded hover:bg-gray-200"
             @click="changeShowType">
             {{ filter.showType === 'mine' ? '전체 글 보기' : '내 글 보기' }}

--- a/src/pages/CommunicationBoard/CommunicationBoard.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoard.vue
@@ -57,15 +57,17 @@ import { onBeforeMount, ref, Ref, computed, ComputedRef, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import moment from 'moment/moment';
 import { query } from '@/composables/graphqlUtils';
-import { CommunicationBoard } from '@/types/CommunicationBoard';
+import { CommunicationBoard, CommunicationBoardDivision } from '@/types/CommunicationBoard';
 import { useUserStore } from '@/stores/user';
 import { TABLE_COLUMNS, DIVISION_OPTIONS, DIVISION_LABEL } from './data';
 
 import getCommunicationBoardsQuery from '@/graphql/getCommunicationBoards.query.gql';
 
+type ShowType = 'mine' | 'all';
 interface Filter {
-  division?: CommunicationBoardDivision,
-  showType: 'mine' | 'all',
+  [key: string]: any;
+  division?: string,
+  showType: ShowType,
   page: number,
 }
 
@@ -82,21 +84,21 @@ const loggedIn: ComputedRef<boolean> = computed(() => userStore.loggedIn);
 const communicationBoards: Ref<CommunicationBoard[]> = ref([]);
 
 const noneDivision = '구분 선택';
-const divisionOptions: ComputedRef<(CommunicationBoardDivision | 'none')[]> = computed(() => {
+const divisionOptions: ComputedRef<(CommunicationBoardDivision | '구분 선택')[]> = computed(() => {
   return [noneDivision, ...DIVISION_OPTIONS];
 });
-const filter: Ref<Filter> = ref({ division: noneDivision, showType: 'all', page: 1 });
+const filter: Ref<Filter> = ref({ division: noneDivision, showType: 'all' as ShowType, page: 1 });
 
 // Filter가 변경될 떄마다 route를 replace해주고, CommunicationBoard data를 가져온다.
 watch(filter, () => {
-  router.replace({ name: 'CommunicationBoard', query: filter.value });
+  router.replace({ name: 'CommunicationBoard', query: { ...filter.value } });
   getCommunicationBoards();
 });
 
 onBeforeMount(() => initialize());
 
 function initialize() {
-  for (const key of ['division', 'showType', 'page']) {
+  for (const key of ['division', 'showTypeㄱ', 'page']) {
     if (!route.query[key]) { continue; }
     filter.value[key] = key === 'page' ? Number(route.query[key]) : route.query[key];
   }
@@ -104,7 +106,7 @@ function initialize() {
 }
 
 function getCommunicationBoards() {
-  const flds = {};
+  const flds: Record<string, any> = {};
   if (filter.value.division !== noneDivision) {
     flds.division = filter.value.division;
   }

--- a/src/pages/CommunicationBoard/CommunicationBoard.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoard.vue
@@ -3,10 +3,14 @@
     <div class="flex flex-col w-4/5 p-10 m-auto bg-white rounded h-4/5">
       <header class="flex pb-4 border-b border-gray-400">
         <div class="flex-1 text-2xl font-bold">소통창구</div>
-        <!-- 글쓰기 버튼 : 로그인한 유저에게만 보인다. -->
-        <div v-if="loggedIn">
-          <router-link to="/communication-board/create"
-            class="px-4 py-1 border border-gray-300 rounded hover:bg-gray-200">글쓰기</router-link>
+
+        <!-- 구분 Filter -->
+        <div class="w-40 text-lg font-extrabold text-center text-primary">
+          <q-select :model-value="filter.division"
+            :options="divisionOptions"
+            :option-label="(opt: CommunicationBoardDivision) => DIVISION_LABEL[opt] || opt"
+            @update:model-value="onChangeDivision"
+            class="mr-4"></q-select>
         </div>
       </header>
 
@@ -29,6 +33,12 @@
             :max="maxPage"
             @update:model-value="onChangePage" />
         </div>
+
+        <!-- 글쓰기 버튼 : 로그인한 유저에게만 보인다. -->
+        <div v-if="loggedIn" class="text-right">
+          <router-link to="/communication-board/create"
+            class="px-4 py-1 border border-gray-300 rounded hover:bg-gray-200">글쓰기</router-link>
+        </div>
       </footer>
     </div>
   </div>
@@ -41,7 +51,7 @@ import moment from 'moment/moment';
 import { query } from '@/composables/graphqlUtils';
 import { CommunicationBoard } from '@/types/CommunicationBoard';
 import { useUserStore } from '@/stores/user';
-import { TABLE_COLUMNS } from './data';
+import { TABLE_COLUMNS, DIVISION_OPTIONS, DIVISION_LABEL } from './data';
 
 import getCommunicationBoardsQuery from '@/graphql/getCommunicationBoards.query.gql';
 
@@ -57,12 +67,23 @@ const maxPage: ComputedRef<number> = computed(() => Math.ceil(total.value / perP
 const loggedIn: ComputedRef<boolean> = computed(() => userStore.loggedIn);
 const communicationBoards: Ref<CommunicationBoard[]> = ref([]);
 
+const noneDivision = '구분 선택';
+const divisionOptions: ComputedRef<(CommunicationBoardDivision | 'none')[]> = computed(() => {
+  return [noneDivision, ...DIVISION_OPTIONS];
+});
+const filter: Ref<{ division?: CommunicationBoardDivision }> = ref({ division: noneDivision });
+
 onBeforeMount(() => getCommunicationBoards());
 
 function getCommunicationBoards() {
+  const flds = {};
+  if (filter.value.division !== noneDivision) {
+    flds.division = filter.value.division;
+  }
   query(getCommunicationBoardsQuery, {
     page: currentPage.value - 1,
     perPage,
+    filter: { flds },
   }, false).then(({ data, error, execute }) => {
     if (!data.value?.communicationBoard) { return; }
     communicationBoards.value = data.value.communicationBoard.data || [];
@@ -78,6 +99,13 @@ function onChangePage() {
 // Table Row 클릭 시
 function onClick(_: Event, row: CommunicationBoard) {
   router.push(`/communication-board/${row._id}`);
+}
+
+// 구분 변경 시
+function onChangeDivision(event: CommunicationBoardDivision) {
+  filter.value.division = event;
+  currentPage.value = 1;
+  getCommunicationBoards();
 }
 </script>
 

--- a/src/pages/CommunicationBoard/CommunicationBoard.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoard.vue
@@ -12,6 +12,14 @@
             @update:model-value="onChangeDivision"
             class="mr-4"></q-select>
         </div>
+
+        <!-- 내 글 보기 / 전체 글 보기 -->
+        <div>
+          <button class="px-4 py-1 border border-gray-400 rounded hover:bg-gray-200"
+            @click="changeShowType">
+            {{ showType === 'mine' ? '전체 글 보기' : '내 글 보기' }}
+          </button>
+        </div>
       </header>
 
       <div class="flex-1 overflow-y-auto">
@@ -72,6 +80,7 @@ const divisionOptions: ComputedRef<(CommunicationBoardDivision | 'none')[]> = co
   return [noneDivision, ...DIVISION_OPTIONS];
 });
 const filter: Ref<{ division?: CommunicationBoardDivision }> = ref({ division: noneDivision });
+const showType: Ref<'mine' | 'all'> = ref('all'); // 보기 타입 (내 글 / 전체 글)
 
 onBeforeMount(() => getCommunicationBoards());
 
@@ -79,6 +88,9 @@ function getCommunicationBoards() {
   const flds = {};
   if (filter.value.division !== noneDivision) {
     flds.division = filter.value.division;
+  }
+  if (showType.value === 'mine') {
+    flds.author = userStore.id;
   }
   query(getCommunicationBoardsQuery, {
     page: currentPage.value - 1,
@@ -105,6 +117,12 @@ function onClick(_: Event, row: CommunicationBoard) {
 function onChangeDivision(event: CommunicationBoardDivision) {
   filter.value.division = event;
   currentPage.value = 1;
+  getCommunicationBoards();
+}
+
+// 보기 타입 변경 (내 글 / 전체 글)
+function changeShowType() {
+  showType.value = showType.value === 'mine' ? 'all' : 'mine';
   getCommunicationBoards();
 }
 </script>

--- a/src/pages/CommunicationBoard/CommunicationBoardDetail.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoardDetail.vue
@@ -86,7 +86,7 @@
       <div v-if="isAdmin && communicaitonBoard.status === 'request'"
         class="flex my-4">
         <input type="text" class="flex-1 px-2 py-1 mr-2 border rounded"
-          :placeholder="메시지" v-model="communicaitonBoard.message" />
+          placeholder="메시지" v-model="communicaitonBoard.message" />
         <button @click="onClickAcceptBtn"
           class="px-4 py-1 mr-2 font-bold text-white rounded bg-primary/80 hover:bg-primary">승인</button>
         <button @click="onClickRejectBtn"
@@ -147,7 +147,7 @@ const userStore = useUserStore();
 
 const userId: ComputedRef<string | undefined> = computed(() => userStore.id);
 const isAdmin: ComputedRef<boolean> = computed(() => userStore.isAdmin);
-const isAuthor: ComputedRef<boolean> = computed(() => communicaitonBoard.value.author?._id === userStore.id);
+const isAuthor: ComputedRef<boolean> = computed(() => communicaitonBoard.value?.author?._id === userStore.id);
 
 const communicaitonBoard: Ref<CommunicationBoard | undefined> = ref();
 const communicaitonBoardOrg: Ref<CommunicationBoard | undefined> = ref();
@@ -271,7 +271,7 @@ function uploadImage(field: Field, file: any, index?: number): Promise<boolean> 
   return axios.post(`http://localhost:3000/file`, formData, {}).then((response) => {
     const fileData = response.data?.data && response.data.data;
     if (proposalData.value && fileData) {
-      if (field.type === 'images') {
+      if (field.type === 'images' && index) {
         proposalData.value[field.key][index] = fileData;
       } else {
         proposalData.value[field.key] = fileData;
@@ -319,7 +319,7 @@ function getInputFields(fields: any, data: any) {
         input[key] = data[key]._id;
         break;
       case 'images':
-        input[key] = data[key] && data[key].map((d) => d._id);
+        input[key] = data[key] && data[key].map((d: any) => d._id);
         break;
       case 'objectList':
         input[key] = [];
@@ -335,8 +335,8 @@ function getInputFields(fields: any, data: any) {
 }
 
 // mutation varialbes로 보낼 input 반환하는 함수
-function getInput() {
-  if (!communicaitonBoard.value) { return; }
+function getInput(): Record<string, any> {
+  if (!communicaitonBoard.value) { return {}; }
   const fields: string[] = ['division', 'title', 'content'];
   const input: Record<string, any> = {};
   for (const field of fields) { input[field] = communicaitonBoard.value[field]; }
@@ -359,12 +359,12 @@ async function onClickSave() {
   } catch (error) { console.error('error : ', error); }
 
   const fields: string[] = ['division', 'title', 'content'];
-  const input = getInput();
+  const input: Record<string, any> = getInput();
 
   // 아카이브인 경우 address의 lat, lng 계산을 해줘야한다.
-  if (input.division === 'archive') {
+  if (input.division === 'archive' && input.archive) {
     try {
-      const { lat, lng } = await getLatLng(input.archive.address);
+      const { lat, lng } = await getLatLng(input.archive!.address);
       input.archive.lat = lat;
       input.archive.lng = lng;
     } catch (_) {}
@@ -383,6 +383,7 @@ async function onClickSave() {
 
 // 재요청 버튼 클릭 시
 function onClickReRequestBtn() {
+  if (!communicaitonBoard.value) { return; }
   mutate(reRequestCommunicationBoard, { id: communicaitonBoard.value._id }).then(({ data }) => {
     const success = !!data?.success;
     if (!success) { $q.notify('재요청에 실패했습니다.'); }
@@ -392,6 +393,7 @@ function onClickReRequestBtn() {
 
 // 관리자 계정 - 승인
 function onClickAcceptBtn() {
+  if (!communicaitonBoard.value) { return; }
   const { _id, message } = communicaitonBoard.value;
   mutate(acceptCommunicationBoard, { id: _id, message }).then(({ data }) => {
     const success = !!data?.success;
@@ -402,6 +404,7 @@ function onClickAcceptBtn() {
 
 // 관리자 계절 - 거절
 function onClickRejectBtn() {
+  if (!communicaitonBoard.value) { return; }
   const { _id, message } = communicaitonBoard.value;
   if (!message) { return $q.notify('거절 시에는 메세지가 필수입니다!'); }
   mutate(rejectCommunicationBoard, { id: _id, message }).then(({ data }) => {

--- a/src/pages/CommunicationBoard/CommunicationBoardDetail.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoardDetail.vue
@@ -14,6 +14,14 @@
             @update:model-value="onChangeDivision"
             class="mr-4"></q-select>
           <span v-else>{{DIVISION_LABEL[communicaitonBoard.division]}}</span>
+
+          <div class="mt-1 text-sm font-bold"
+            :class="{
+              'text-primary': communicaitonBoard.status === 'accept',
+              'text-red-600': communicaitonBoard.status === 'reject',
+              'text-green-600': communicaitonBoard.status === 'request'}">
+            {{ STATUS_LABEL[communicaitonBoard.status] }}
+          </div>
         </div>
 
         <div class="flex-1 text-base">
@@ -41,10 +49,6 @@
               <button class="hover:text-gray-800" @click="onClickDeleteBtn">삭제</button>
             </div>
           </div>
-        </div>
-
-        <div>
-          {{ STATUS_LABEL[communicaitonBoard.status] }}
         </div>
       </div>
 

--- a/src/pages/CommunicationBoard/CommunicationBoardDetail.vue
+++ b/src/pages/CommunicationBoard/CommunicationBoardDetail.vue
@@ -84,13 +84,19 @@
 
       <!-- 현재 계정이 관리자 계정이면서, 해당 게시글의 상태가 제안인 경우 -->
       <div v-if="isAdmin && communicaitonBoard.status === 'request'"
-        class="flex px-4">
-        <input type="text" class="flex-1 py-1 mr-2 border rounded"
+        class="flex my-4">
+        <input type="text" class="flex-1 px-2 py-1 mr-2 border rounded"
           :placeholder="메시지" v-model="communicaitonBoard.message" />
         <button @click="onClickAcceptBtn"
           class="px-4 py-1 mr-2 font-bold text-white rounded bg-primary/80 hover:bg-primary">승인</button>
         <button @click="onClickRejectBtn"
           class="px-4 py-1 font-bold text-white bg-red-600 rounded hover:bg-red-800">거절</button>
+      </div>
+
+      <div v-if="communicaitonBoard.status !== 'request' && communicaitonBoard.message"
+        class="flex my-4">
+        <div class="self-center w-40 font-bold text-gray-800 border-r border-gray-400">관리자 {{STATUS_LABEL[communicaitonBoard.status]}} 메세지</div>
+        <div class="flex-1 px-4 py-2 ml-4 border border-gray-200 rounded">{{communicaitonBoard.message}}</div>
       </div>
 
       <div class="text-right">
@@ -102,7 +108,7 @@
         </template>
         <template v-else>
           <button v-if="isAuthor && communicaitonBoard.status === 'reject'"
-            class="px-8 py-2 mr-2 border rounded border-primary text-primary hover:bg-primary !hover:text-white"
+            class="px-8 py-2 mr-2 border rounded border-primary text-primary/80 hover:bg-primary hover:text-white"
             @click="onClickReRequestBtn">재요청</button>
           <button class="px-8 py-2 border border-gray-200 rounded hover:bg-gray-100"
             @click="goToTableView">목록</button>
@@ -181,7 +187,7 @@ function getData(id: string) {
     return;
   }
 
-  query(getCommunicationBoard, { id }).then((resp) => {
+  query(getCommunicationBoard, { id }, false).then((resp) => {
     const data = resp.data?.value?.CommunicationBoard;
     if (!data) {
       $q.notify('존재하지 않는 게시글입니다.');

--- a/src/pages/CommunicationBoard/components/CustomInput.vue
+++ b/src/pages/CommunicationBoard/components/CustomInput.vue
@@ -1,8 +1,8 @@
 <template>
   <!-- 이미지 -->
-  <q-file v-if="field.type === 'image'" name="data_file"
+  <q-file v-if="field.type === 'image' || field.type === 'images'" name="data_file"
     :model-value="(modelValue as File)" @update:model-value="onUpdate" filled
-    :label="field.label" :disable="disabled" />
+    :multiple="field.type === 'images'" :label="field.label" :disable="disabled" />
 
   <!-- 컬러 -->
   <q-input v-else-if="field.type === 'color'"
@@ -46,10 +46,23 @@
       :disable="disabled" :options="selectOptions" :option-label="opt => opt.name"></q-select>
   </div>
 
+  <!-- Address -->
+  <div v-else-if="field.type === 'address'" class="flex">
+    <div class="flex-1">{{modelValue}}</div>
+    <div class="text-right w-22">
+      <button class="px-4 py-1 border border-gray-400 rounded hover:bg-gray-200"
+        @click="() => { isOpenFindAddressDialog = true; }">주소 찾기</button>
+    </div>
+  </div>
+
   <!-- 그 외 (text, date ..) -->
-  <q-input v-else-if="field.type === 'text' || field.type === 'date'" :type="field.type"
+  <q-input v-else-if="field.type === 'text' || field.type === 'date' || field.type === 'url'" :type="field.type"
     :model-value="modelValue" @update:model-value="onUpdate"
     :placeholder="field.label" class="w-full" :disable="disabled" />
+
+  <FindAddressDialog :show="isOpenFindAddressDialog"
+    @done="onUpdate"
+    @close="() => { isOpenFindAddressDialog = false; }" />
 </template>
 
 <script lang="ts">
@@ -59,31 +72,48 @@ export default {
 </script>
 
 <script setup lang="ts">
-import { onBeforeMount, computed, ComputedRef } from 'vue';
+import { onBeforeMount, computed, ComputedRef, ref, Ref } from 'vue';
 import { useGroupStore } from '@/stores/group';
+import { useArtistStore } from '@/stores/artist';
 import { Field } from '../data';
+
+// Dialogs
+import FindAddressDialog from '@/dialogs/FindAddressDialog.vue';
 
 interface Props {
   modelValue: any;
   field: Field;
   disabled: boolean;
+  parent?: any;
 }
 
 const props = withDefaults(defineProps<Props>(), {});
 const emit = defineEmits(['update:modelValue']);
 
 const groupStore = useGroupStore();
+const aritstStore = useArtistStore();
+
+const isOpenFindAddressDialog: Ref<boolean> = ref(false);
 
 onBeforeMount(() => {
-  const { type, key } = props.field;
-  if (type === 'select' && key === 'group') {
+  const { type, key, parent } = props.field;
+  if (type !== 'select') { return; }
+  if (key === 'group') {
     groupStore.getGroups();
+  } else if (key == 'artist') {
+    const flds = {};
+    if (props.parent) { flds[parent] = props.parent; }
+    aritstStore.getArtists({ flds });
   }
 });
 
 const selectOptions: ComputedRef<Record<string, any>[]> = computed(() => {
   if (props.field.type !== 'select' || props.disabled) { return []; }
-  if (props.field.key === 'group') { return groupStore.groups; }
+
+  switch (props.field.key) {
+    case 'group': return groupStore.groups;
+    case 'artist': return aritstStore.artists;
+  }
   return [];
 });
 
@@ -97,6 +127,7 @@ function removeObject(index: number) {
 }
 
 function onUpdate(event: string | number | null) {
+  isOpenFindAddressDialog.value = false;
   emit('update:modelValue', event);
 }
 </script>

--- a/src/pages/CommunicationBoard/components/CustomInput.vue
+++ b/src/pages/CommunicationBoard/components/CustomInput.vue
@@ -101,8 +101,8 @@ onBeforeMount(() => {
   if (key === 'group') {
     groupStore.getGroups();
   } else if (key == 'artist') {
-    const flds = {};
-    if (props.parent) { flds[parent] = props.parent; }
+    const flds: Record<string, any> = {};
+    if (parent && props.parent) { flds[parent] = props.parent; }
     aritstStore.getArtists({ flds });
   }
 });

--- a/src/pages/CommunicationBoard/data.ts
+++ b/src/pages/CommunicationBoard/data.ts
@@ -76,6 +76,7 @@ export interface Field {
   label: string;
   key: string;
   required: boolean;
+  parent?: string;
   objectFields?: Field[];
 }
 
@@ -103,7 +104,26 @@ const ARTIST_FORM: Field[] = [
   { label: '그룹', key: 'group', required: true, type: 'select' },
 ];
 
+const ARCHIVE_FORM: Field[] = [
+  { label: '그룹', key: 'group', required: true, type: 'select' },
+  { label: '아티스트', key: 'artist', required: false, type: 'select', parent: 'group' },
+  { label: '카페 테마 이름', key: 'themeName', required: true, type: 'text' },
+  { label: '카페 이름', key: 'name', required: true, type: 'text' },
+  { label: '주소', key: 'address', required: true, type: 'address' },
+  { label: '상세 주소', key: 'detailAddress', required: false, type: 'text', parent: 'address' },
+  { label: '주최자 (트위터 ID)', key: 'organizer', required: true, type: 'text' },
+  { label: '시작일', key: 'startDate', required: true, type: 'date' },
+  { label: '종료일', key: 'endDate', required: true, type: 'date' },
+  // { label: '오픈 시간', key: 'openTime', required: false, type: 'time' },
+  // { label: '종료 시간', key: 'closeTime', required: false, type: 'time' },
+  { label: '메인 이미지', key: 'mainImage', required: true, type: 'image' },
+  { label: '서브 이미지들', key: 'images', required: false, type: 'images' },
+  { label: '번호', key: 'phoneNumber', required: false, type: 'text' },
+  { label: '링크', key: 'link', required: false, type: 'url' },
+];
+
 export const DATA_FORM: Record<string, Field[]> = {
   group: GROUP_FROM,
   artist: ARTIST_FORM,
+  archive: ARCHIVE_FORM
 };

--- a/src/pages/CommunicationBoard/data.ts
+++ b/src/pages/CommunicationBoard/data.ts
@@ -1,4 +1,3 @@
-import moment from 'moment/moment';
 import { CommunicationBoard } from '@/types/CommunicationBoard';
 import { formatDate } from '@/composables/formatDate';
 
@@ -43,7 +42,13 @@ export const TABLE_COLUMNS: Record<string, any>[] = [
     label: '작성자',
     align: 'center',
     field: (row: CommunicationBoard) => row.author?.name,
-  }
+  }, {
+    name: 'status',
+    required: false,
+    label: '상태',
+    align: 'center',
+    field: (row: CommunicationBoard) => STATUS_LABEL[row.status],
+  },
 ];
 
 export const DIVISION_LABEL: Record<string, string> = {
@@ -53,6 +58,13 @@ export const DIVISION_LABEL: Record<string, string> = {
   // archive: '카페 제안',
   improvement: '기능 개선',
   error: '에러'
+};
+
+export const STATUS_LABEL: Record<string, string> = {
+  none: '',
+  request: '제안',
+  accept: '승인',
+  reject: '거절'
 };
 
 export interface Field {

--- a/src/pages/CommunicationBoard/data.ts
+++ b/src/pages/CommunicationBoard/data.ts
@@ -49,7 +49,7 @@ export const TABLE_COLUMNS: QTableProps['columns'] = [
     required: false,
     label: '상태',
     align: 'center',
-    field: (row: any) => STATUS_LABEL[row.status],
+    field: (row: any) => STATUS_LABEL[row.status] || '-',
   },
 ];
 
@@ -61,6 +61,8 @@ export const DIVISION_LABEL: Record<CommunicationBoardDivision, string> = {
   improvement: '기능 개선',
   error: '에러'
 };
+
+export const DIVISION_OPTIONS: CommunicationBoardDivision[] = Object.keys(DIVISION_LABEL) as CommunicationBoardDivision[];
 
 export const STATUS_LABEL: Record<string, string> = {
   none: '',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -37,7 +37,7 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import("@/pages/ArchiveDetail.vue")
   },
   {
-    meta: { title: "favorite", layout: "MainLayout"},
+    meta: { title: "favorite", layout: "MainLayout" },
     path: "/favorite",
     beforeEnter: authUser,
     component: () => import("@/pages/favorite.vue")
@@ -45,6 +45,7 @@ const routes: Array<RouteRecordRaw> = [
 
   {
     meta: { title: "소통 창구", layout: "MainLayout" },
+    name: 'CommunicationBoard',
     path: "/communication-board",
     component: () => import("@/pages/CommunicationBoard/CommunicationBoard.vue")
   },


### PR DESCRIPTION
## ⭐️ 구현한 기능
1. 소통창구 - 카페(Archive) 제안 
  - 기존 `Admin/Archive.vue`에 있던 `getLatLng` 함수를 `composables/addressUtils.ts`에 분리.
3. 소통창구 Table 필터 추가
   - 구분(division) Filter
   - 내 글 보기 / 전체 글 보기
4. 소통창구 Table 과 상세 화면에 현재 제안 상태(status) 추가
5. 소통창구 상세 화면에서 관리자인 경우, 승인/거절 기능 추가
6. 소통창구 상세 화면 - 거절 당했을 경우 재요청 기능 추가

## ✏️ 참고해야하는 부분
- 아카이브 시간 관련해서는 날짜/요일 별로 open/close 시간이 달라지는 경우도 있어서, 수정이 필요할 거 같습니다. 때문에 카페 제안에서는 해당 필드를 주석 처리 해두었습니다.
- ⚠️ 실행 시 archive-back #48 PR이 머지되지 않았다면 서버 쪽 코드는 `mod/communication-board` 브랜치로 이동하여 실행해주세요 ! 

## 🖥️ 실행 화면

### 카페 제안
![ezgif com-video-to-gif (16)](https://github.com/anniversaryArchive/archive/assets/31975198/22e81005-87df-4316-8fd6-c04e546ae35c)

### 관리자 거절 
![ezgif com-video-to-gif (17)](https://github.com/anniversaryArchive/archive/assets/31975198/065cf42f-7a2a-408c-a5cd-3eb35cc19966)

### 재요청 
![ezgif com-video-to-gif (18)](https://github.com/anniversaryArchive/archive/assets/31975198/23b204d4-faea-4f78-b34f-b6c566ddacbe)

