### PR TITLE
즐겨찾기 기능 - 카페 맵/상세 화면 

### DIFF
--- a/src/components/CafeItem.vue
+++ b/src/components/CafeItem.vue
@@ -1,8 +1,8 @@
 <template>
   <q-item class="archive-item" clickable @click="onClickItem">
     <q-item-section>
-      <div class="grid grid-flow-row-dense grid-cols-2">
-        <q-item-label class="overflow-hidden leading-7 text-ellipsis whitespace-nowrap">{{
+      <div class="flex">
+        <q-item-label class="flex-1 overflow-hidden leading-7 text-ellipsis whitespace-nowrap">{{
           archive.themeName
         }}</q-item-label>
         <q-button class="text-right" @click="onClickFavoriteIcon">

--- a/src/components/FavoriteGroupList.vue
+++ b/src/components/FavoriteGroupList.vue
@@ -18,7 +18,10 @@
           >
             <q-icon name="favorite" class="m-auto text-white" />
           </div>
-          <div class="font-semibold">{{ item.title }}</div>
+          <div class="font-semibold">
+            {{ item.title }}
+            <span v-if="!selectable">({{ item.archives?.length || 0 }})</span>
+          </div>
         </div>
 
         <span v-if="selectable">

--- a/src/components/FavoriteGroupList.vue
+++ b/src/components/FavoriteGroupList.vue
@@ -1,29 +1,35 @@
 <template>
-  <ul>
+  <ul class="flex flex-col max-h-full overflow-y-hidden flex-nowrap">
     <li class="flex px-4 py-4 font-semibold border-b border-gray-300" @click="isShowCreateFavoriteDialog = true">
       <q-icon name="add_circle_outline" size="sm" class="my-auto text-gray-300" />
       <div class="flex-1 my-auto ml-2 text-gray-600">새 즐겨찾기 만들기</div>
     </li>
 
-    <li
-      v-for="item in list"
-      class="flex flex-wrap px-4 py-4 border-b border-gray-300 cursor-pointer hover:bg-gray-100"
-      @click="emit('click', item._id)"
-    >
-      <div class="flex flex-1 my-auto">
-        <div
-          class="flex flex-col justify-center w-5 h-5 mr-2 text-center rounded-full"
-          :style="`background-color: ${item.color}`"
-        >
-          <q-icon name="favorite" class="m-auto text-white" />
+    <ul class="overflow-y-auto">
+      <li
+        v-for="item in list"
+        class="flex flex-wrap px-4 py-4 border-b border-gray-300 cursor-pointer hover:bg-gray-100"
+        @click="emit('click', item._id)"
+      >
+        <div class="flex flex-1 my-auto">
+          <div
+            class="flex flex-col justify-center w-5 h-5 mr-2 text-center rounded-full"
+            :style="`background-color: ${item.color}`"
+          >
+            <q-icon name="favorite" class="m-auto text-white" />
+          </div>
+          <div class="font-semibold">{{ item.title }}</div>
         </div>
-        <div class="font-semibold">{{ item.title }}</div>
-      </div>
 
-      <span v-if="selectable">
-        <q-checkbox :modelValue="item.selected || false" @update:modelValue="item.selected = $event" />
-      </span>
-    </li>
+        <span v-if="selectable">
+          <q-checkbox :modelValue="item.selected || false" @update:modelValue="item.selected = $event" />
+        </span>
+      </li>
+    </ul>
+
+    <div v-if="selectable" class="px-2 py-2 text-center">
+      <button class="w-full py-2 font-bold text-white rounded bg-primary" @click="onClickSaveBtn">저장</button>
+    </div>
   </ul>
 
   <!-- 즐겨찾기 추가 Bottom Dialog -->
@@ -70,7 +76,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), { selectable: false });
-const emit = defineEmits(['click']);
+const emit = defineEmits(['click', 'select']);
 
 const favoriteGroupStore = useFavoriteGroupStore();
 
@@ -101,6 +107,12 @@ async function create() {
   } finally {
     createFavoriteGroup.value = { title: '' };
   }
+}
+
+// save favorite selected
+function onClickSaveBtn() {
+  const selectedList = list.value.filter(({ selected }) => selected);
+  emit('select', selectedList);
 }
 </script>
 

--- a/src/components/FavoriteGroupList.vue
+++ b/src/components/FavoriteGroupList.vue
@@ -92,6 +92,11 @@ watch(
   _ => initList(),
 );
 
+watch(
+  () => favoriteGroupStore.list,
+  _ => initList(),
+);
+
 function initList() {
   list.value = _.cloneDeep(favoriteGroupStore.list).map(item => {
     item.selected = props.selected?.some(({ _id }) => item._id === _id);

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -111,7 +111,7 @@ function onLoadInfoWindow(infoWindowObject: any) {
 }
 
 function setSelectedArchive(archive: Archive) {
-  mapStore.selectedArchive = archive;
+  mapStore.selectedArchive = { ...archive };
 }
 
 function onClickDetailBtn(id: string | undefined) {

--- a/src/dialogs/BottomDialog.vue
+++ b/src/dialogs/BottomDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="absolute relative top-0 left-0 w-full h-full dialog" :class="{ hide: !show }">
+  <div class="absolute top-0 left-0 w-full h-full dialog" :class="{ hide: !show }">
     <div class="w-full h-full bg-black backdrop" @click="hide"></div>
     <div
       class="absolute bottom-0 flex flex-col w-full bg-white !rounded-t-2xl dialog-content h-5/6"
@@ -16,7 +16,7 @@
       </div>
 
       <!-- Content -->
-      <div class="flex-1">
+      <div class="flex-1 overflow-y-auto">
         <slot name="content"></slot>
       </div>
 

--- a/src/graphql/getArchive.query.gql
+++ b/src/graphql/getArchive.query.gql
@@ -1,5 +1,5 @@
 query ($id: ID!) {
-  archive (id: $id) {
+  archive(id: $id) {
     _id
     name
     themeName
@@ -36,6 +36,9 @@ query ($id: ID!) {
       path
     }
     favorite
+    favoriteGroup {
+      _id
+    }
     organizer
     phoneNumber
     link

--- a/src/graphql/getArchives.query.gql
+++ b/src/graphql/getArchives.query.gql
@@ -1,5 +1,21 @@
-query ($page: Int, $perPage: Int, $filter: FilterOption, $start: Date, $end: Date, $sortOrder: Int, $sortField: String) {
-  archive: ArchivePagination (page: $page, perPage: $perPage, filter: $filter, start: $start, end: $end, sortOrder: $sortOrder, sortField: $sortField) {
+query (
+  $page: Int
+  $perPage: Int
+  $filter: FilterOption
+  $start: Date
+  $end: Date
+  $sortOrder: Int
+  $sortField: String
+) {
+  archive: ArchivePagination(
+    page: $page
+    perPage: $perPage
+    filter: $filter
+    start: $start
+    end: $end
+    sortOrder: $sortOrder
+    sortField: $sortField
+  ) {
     data {
       _id
       name
@@ -37,7 +53,9 @@ query ($page: Int, $perPage: Int, $filter: FilterOption, $start: Date, $end: Dat
         name
         path
       }
-      favorite
+      favoriteGroup {
+        _id
+      }
       organizer
       phoneNumber
       link

--- a/src/graphql/updateFavoriteGroupsInArchive.mutate.gql
+++ b/src/graphql/updateFavoriteGroupsInArchive.mutate.gql
@@ -1,0 +1,5 @@
+mutation ($archive: ID!, $favoriteGroups: [ID]!) {
+  favoriteGroups: updateFavoriteGroupsInArchive(archive: $archive, favoriteGroups: $favoriteGroups) {
+    _id
+  }
+}

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -24,7 +24,7 @@
     </q-drawer>
     <q-page-container>
       <q-page>
-        <div id="troublemaker" class="bg-[#fff] h-screen mt-[-3.5rem] pt-14">
+        <div id="troublemaker" class="bg-[#fff] h-screen mt-[-3.5rem] pt-14 overflow-y-hidden">
           <slot />
         </div>
       </q-page>

--- a/src/pages/ArchiveDetail.vue
+++ b/src/pages/ArchiveDetail.vue
@@ -1,104 +1,118 @@
 <template>
-  <div
-    v-if="archive"
-    :style="`background-image: url(${mainImage})`"
-    class="relative text-white bg-center bg-cover h-96 sm:h-80"
-  >
-    <div class="absolute top-0 left-0 w-full h-full bg-black/70"></div>
-    <div
-      class="absolute top-1/2 translate-y-[-50%] translate-x-[-50%] left-[50%] w-[90%] md:w-auto md:left-28 md:translate-x-0 text-center md:!text-left"
-    >
-      <!-- 아티스트 명 + 생일 카페 -->
-      <div class="text-2xl font-black">
-        <span class="text-primary">{{ archive.artist?.name }}</span>
-        <span>&nbsp;생일 카페</span>
+  <div class="h-screen relative overflow-hidden">
+    <div class="h-screen overflow-y-auto">
+      <div
+        v-if="archive"
+        :style="`background-image: url(${mainImage})`"
+        class="relative text-white bg-center bg-cover h-96 sm:h-80"
+      >
+        <div class="absolute top-0 left-0 w-full h-full bg-black/70"></div>
+        <div
+          class="absolute top-1/2 translate-y-[-50%] translate-x-[-50%] left-[50%] w-[90%] md:w-auto md:left-28 md:translate-x-0 text-center md:!text-left"
+        >
+          <!-- 아티스트 명 + 생일 카페 -->
+          <div class="text-2xl font-black">
+            <span class="text-primary">{{ archive.artist?.name }}</span>
+            <span>&nbsp;생일 카페</span>
+          </div>
+
+          <!-- 카페 테마 명 -->
+          <div class="mt-2 mb-3 font-black archive-theme">
+            <div class="inline-block text-5xl align-middle">
+              {{ archive.themeName }}
+            </div>
+          </div>
+
+          <!-- 주최자 -->
+          <div class="text-[#D9D9D980] text-lg mb-3">{{ archive.organizer }}</div>
+
+          <!-- 해시태그 : 지역, 아티스트, 실제 카페 명 -->
+          <div>
+            <!-- 그룹명 -->
+            <div :class="classes.hashtag">#{{ archive.group?.name }}</div>
+            <!-- 아티스트 -->
+            <div :class="classes.hashtag">#{{ archive.artist?.name }}</div>
+            <!-- 실제 카페 명 -->
+            <div :class="classes.hashtag" class="!mr-0">#{{ archive.name }}</div>
+          </div>
+        </div>
+        <!-- 즐겨찾기 버튼 -->
+        <span
+          class="absolute bottom-10 left-[50%] md:left-auto translate-x-[-50%] md:translate-x-0 md:right-14 inline-block w-10 h-10 mr-2 text-xl md:text-3xl text-left align-middle rounded-full cursor-pointer"
+          @click="onClickFavoriteIcon"
+        >
+          <q-icon v-if="archive.favorite" name="favorite" class="!inline m-auto text-primary !text-5xl" />
+          <q-icon v-else name="favorite_outline" class="!inline m-auto text-primary !text-5xl" />
+        </span>
       </div>
 
-      <!-- 카페 테마 명 -->
-      <div class="mt-2 mb-3 font-black archive-theme">
-        <div class="inline-block text-5xl align-middle">
-          {{ archive.themeName }}
+      <div class="px-6 md:px-28">
+        <div class="inline-block pt-20 pb-2 text-3xl font-bold border-b-2 border-black">기본 정보</div>
+
+        <div v-if="archive" class="text-xl text-gray-800 mt-11">
+          <div>
+            <span class="inline-block w-8"><q-icon name="calendar_today" /></span>
+            <span class="align-middle">{{ startDate }} ~ {{ endDate }}</span>
+          </div>
+          <div class="my-3">
+            <span class="inline-block w-8"><q-icon name="schedule" /></span>
+            {{ openTime }} ~ {{ closeTime }}
+          </div>
+          <div>
+            <span class="inline-block w-8"><q-icon name="location_on" /></span>
+            <a :href="`https://map.naver.com/v5/search/${archive.address}`" class="border-b border-gray-800">
+              {{ archive.address }} {{ archive.detailAddress }}
+            </a>
+          </div>
+
+          <div class="my-3">
+            <span class="inline-block w-8">
+              <img src="@/assets/twitter.svg" class="w-5" />
+            </span>
+            <a :href="link" class="leading-5 break-words border-b border-gray-800">{{ link }}</a>
+          </div>
+        </div>
+
+        <div class="inline-block pt-20 pb-2 text-3xl font-bold border-b-2 border-black">포스터 및 특전 정보</div>
+
+        <div class="pb-20 mt-4">
+          <ImageSlide :modelValue="images" :editMode="false" />
         </div>
       </div>
-
-      <!-- 주최자 -->
-      <div class="text-[#D9D9D980] text-lg mb-3">{{ archive.organizer }}</div>
-
-      <!-- 해시태그 : 지역, 아티스트, 실제 카페 명 -->
-      <div>
-        <!-- 그룹명 -->
-        <div :class="classes.hashtag">#{{ archive.group?.name }}</div>
-        <!-- 아티스트 -->
-        <div :class="classes.hashtag">#{{ archive.artist?.name }}</div>
-        <!-- 실제 카페 명 -->
-        <div :class="classes.hashtag" class="!mr-0">#{{ archive.name }}</div>
-      </div>
-    </div>
-    <!-- 즐겨찾기 버튼 -->
-    <span
-      class="absolute bottom-10 left-[50%] md:left-auto translate-x-[-50%] md:translate-x-0 md:right-14 inline-block w-10 h-10 mr-2 text-xl md:text-3xl text-left align-middle rounded-full cursor-pointer"
-      @click="onClickFavoriteIcon"
-    >
-      <q-icon v-if="archive.favorite" name="favorite" class="!inline m-auto text-primary !text-5xl" />
-      <q-icon v-else name="favorite_outline" class="!inline m-auto text-primary !text-5xl" />
-    </span>
-  </div>
-
-  <div class="px-6 md:px-28">
-    <div class="inline-block pt-20 pb-2 text-3xl font-bold border-b-2 border-black">기본 정보</div>
-
-    <div v-if="archive" class="text-xl text-gray-800 mt-11">
-      <div>
-        <span class="inline-block w-8"><q-icon name="calendar_today" /></span>
-        <span class="align-middle">{{ startDate }} ~ {{ endDate }}</span>
-      </div>
-      <div class="my-3">
-        <span class="inline-block w-8"><q-icon name="schedule" /></span>
-        {{ openTime }} ~ {{ closeTime }}
-      </div>
-      <div>
-        <span class="inline-block w-8"><q-icon name="location_on" /></span>
-        <a :href="`https://map.naver.com/v5/search/${archive.address}`" class="border-b border-gray-800">
-          {{ archive.address }} {{ archive.detailAddress }}
-        </a>
-      </div>
-
-      <div class="my-3">
-        <span class="inline-block w-8">
-          <img src="@/assets/twitter.svg" class="w-5" />
-        </span>
-        <a :href="link" class="leading-5 break-words border-b border-gray-800">{{ link }}</a>
-      </div>
     </div>
 
-    <div class="inline-block pt-20 pb-2 text-3xl font-bold border-b-2 border-black">포스터 및 특전 정보</div>
-
-    <div class="pb-20 mt-4">
-      <ImageSlide :modelValue="images" :editMode="false" />
-    </div>
+    <BottomDialog :show="isShowFavoriteGroupBottomDialog" @hide="isShowFavoriteGroupBottomDialog = false">
+      <template #content>
+        <FavoriteGroupList :selectable="true" :selected="archive?.favoriteGroup" @select="selectFavoriteGroupList" />
+      </template>
+    </BottomDialog>
   </div>
 </template>
 
 <script setup lang="ts">
 import { onBeforeMount, ref, Ref, computed, ComputedRef } from 'vue';
 import { useRoute } from 'vue-router';
+import moment from 'moment';
+import { useQuasar } from 'quasar';
+
 import { useArchiveStore } from '@/stores/archive';
 import { useUserStore } from '@/stores/user';
-import { useFavoriteArchiveStore } from '@/stores/favoriteArchive';
+import { useFavoriteGroupStore } from '@/stores/favoriteGroup';
 import { Archive } from '@/types/Archive';
 import { Image } from '@/types/Image';
 import ImageSlide from '@/components/common/imageSlide.vue';
-import LayoutHeader from '@/layouts/LayoutHeader.vue';
-import moment from 'moment';
-import { useQuasar } from 'quasar';
+import BottomDialog from '@/dialogs/BottomDialog.vue';
+import FavoriteGroupList from '@/components/FavoriteGroupList.vue';
+import { arch } from 'os';
 
 const $q = useQuasar();
 const route = useRoute();
 const archiveStore = useArchiveStore();
-const favoriteArchiveStore = useFavoriteArchiveStore();
+const favoriteGroupStore = useFavoriteGroupStore();
 const userStore = useUserStore();
 
 const archive: Ref<Archive | undefined> = ref();
+const isShowFavoriteGroupBottomDialog = ref(false);
 
 const classes: Record<string, string> = {
   hashtag: 'inline-block px-3 py-1 mr-2 bg-[#D9D9D980] text-white rounded-full',
@@ -150,6 +164,7 @@ const images: ComputedRef<Record<string, any>[]> = computed(() => {
 
 onBeforeMount(() => {
   getArchive();
+  favoriteGroupStore.getFavoriteGroupList();
 });
 
 async function getArchive() {
@@ -169,17 +184,21 @@ function numToTime(num: number): string {
 async function onClickFavoriteIcon() {
   // 로그인되어 있지 않은 경우, 경고 메세지를 띄워준다.
   if (!userStore.loggedIn) return $q.notify('즐겨찾기 기능은 로그인 시 이용 가능합니다.');
+  isShowFavoriteGroupBottomDialog.value = true;
+}
 
-  let success: any = false;
+// 즐겨찾기 그룹 변경 완료 시
+async function selectFavoriteGroupList(ids: string[]) {
+  if (!archive.value) return;
   try {
-    if (archive.value!.favorite) {
-      success = await favoriteArchiveStore.doRemoveFavorite(archive.value!._id);
-    } else {
-      success = await favoriteArchiveStore.doCreateFavorite(archive.value!._id);
-    }
-    if (!success) return;
-    archive.value!.favorite = !archive.value!.favorite;
-  } catch (_) {}
+    const favoriteGroups = await favoriteGroupStore.updateFavoriteGroupsInArchive(archive.value._id, ids);
+    archive.value.favoriteGroup = favoriteGroups;
+    archive.value.favorite = favoriteGroups?.length > 0;
+  } catch (error) {
+    console.error('[ERROR] select favorite group list : ', error);
+  } finally {
+    isShowFavoriteGroupBottomDialog.value = false;
+  }
 }
 </script>
 

--- a/src/pages/FavoriteArchives.vue
+++ b/src/pages/FavoriteArchives.vue
@@ -75,7 +75,7 @@ function onClickArchive(archive: Archive) {
   if ($q.screen.xs) {
     router.push(`/archive/${archive._id}`);
   } else {
-    mapStore.selectedArchive = archive;
+    mapStore.selectedArchive = { ...archive };
   }
 }
 

--- a/src/pages/cafeMap.vue
+++ b/src/pages/cafeMap.vue
@@ -57,14 +57,14 @@
 
     <BottomDialog :show="isShowFavoriteGroupBottomDialog" @hide="isShowFavoriteGroupBottomDialog = false">
       <template #content>
-        <FavoriteGroupList :selectable="true" />
+        <FavoriteGroupList :selectable="true" :selected="clickedArchive?.favoriteGroup" />
       </template>
     </BottomDialog>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeMount, ref, watch } from 'vue';
+import { defineComponent, onBeforeMount, ref, Ref, watch } from 'vue';
 import { NaverInfoWindow, NaverMap, NaverMarker } from 'vue3-naver-maps';
 import mixinPageCommon from '@/pages/mixin/mixinPageCommon';
 import ccobject from '@/composables/createComObject';
@@ -73,6 +73,7 @@ import cscript from '@/composables/comScripts';
 import { Archive, ArchiveSearchParams } from '@/types/Archive';
 import { useArchiveStore } from '@/stores/archive';
 import { useMapStore } from '@/stores/map';
+import { useFavoriteGroupStore } from '@/stores/favoriteGroup';
 import _ from 'lodash';
 import { Pagination } from '@/types/CommonTypes';
 import moment from 'moment';
@@ -98,7 +99,6 @@ export default defineComponent({
     // 아티스트 멀티 셀렉트박스 배열 변수
     const artistList = ref([] as string[]);
 
-    const map = ref();
     const markerData = ref({} as Archive);
     const mapOptions = {
       latitude: 37.51747, // 지도 중앙 위도
@@ -123,6 +123,7 @@ export default defineComponent({
     const artistStore = useArtistStore();
     const archiveStore = useArchiveStore();
     const mapStore = useMapStore();
+    const favoriteGroupStore = useFavoriteGroupStore();
 
     onBeforeMount(() => {
       initialize();
@@ -135,6 +136,7 @@ export default defineComponent({
       };
       artistStore.getArtists(artistFilterData);
       getArchives();
+      favoriteGroupStore.getFavoriteGroupList();
     };
 
     watch(
@@ -267,10 +269,12 @@ export default defineComponent({
     }
 
     const isShowFavoriteGroupBottomDialog = ref(false);
+    const clickedArchive: Ref<Archive | null> = ref(null);
 
     // 즐겨찾기 버튼 클릭 시
     async function onClickFavorite(archive: Archive) {
       isShowFavoriteGroupBottomDialog.value = true;
+      clickedArchive.value = archive;
     }
 
     return {
@@ -293,6 +297,7 @@ export default defineComponent({
       onClickFavorite,
       isShowFavoriteGroupBottomDialog,
       onClickArchive,
+      clickedArchive,
     };
   },
 });

--- a/src/pages/cafeMap.vue
+++ b/src/pages/cafeMap.vue
@@ -293,7 +293,6 @@ export default defineComponent({
         const favoriteGroups = await favoriteGroupStore.updateFavoriteGroupsInArchive(clickedArchive.value!._id, ids);
         clickedArchive.value!.favoriteGroup = favoriteGroups;
         clickedArchive.value!.favorite = favoriteGroups?.length > 0;
-        const foundIndex = archiveParams.value.findIndex((item: Archive) => item._id === clickedArchive.value!._id);
       } catch (error) {
         console.error('[ERROR] select favorite group list : ', error);
       } finally {

--- a/src/pages/cafeMap.vue
+++ b/src/pages/cafeMap.vue
@@ -261,7 +261,7 @@ export default defineComponent({
       // 모바일인 경우, 바로 상세 페이지로 넘어간다.
       if ($q.screen.xs) return this.$router.push(`/archive/${archive._id}`);
       // 그 외, 맵에서 Info Component를 띄워준다.
-      mapStore.selectedArchive = archive;
+      mapStore.selectedArchive = { ...archive };
     }
 
     function paginationChange() {

--- a/src/stores/favoriteGroup.ts
+++ b/src/stores/favoriteGroup.ts
@@ -3,6 +3,7 @@ import { query, mutate } from '@/composables/graphqlUtils';
 import { FavoriteGroup } from '@/types/FavoriteGroup';
 import getFavoriteGroupList from '@/graphql/getFavoriteGroupList.query.gql';
 import createFavoriteGroup from '@/graphql/createFavoriteGroup.mutate.gql';
+import updateFavoriteGroupsInArchive from '@/graphql/updateFavoriteGroupsInArchive.mutate.gql';
 
 interface FavoriteGroupState {
   favoriteGroupList: FavoriteGroup[];
@@ -32,6 +33,17 @@ export const useFavoriteGroupStore = defineStore({
         return id;
       } catch (_) {
         return;
+      }
+    },
+    async updateFavoriteGroupsInArchive(archive: string, favoriteGroups: string[]) {
+      try {
+        const { data } = await mutate(updateFavoriteGroupsInArchive, {
+          archive,
+          favoriteGroups,
+        });
+        return data?.favoriteGroups || [];
+      } catch (error) {
+        console.error('[ERROR] update favorite groups in archive : ', error);
       }
     },
   },


### PR DESCRIPTION
### ✨ 수정 사항
1. `CafeItem` component - 즐겨찾기 버튼 영역 수정 
    - 기존 즐겨찾기 영역이 `grid grid-cols-2`로 가로 영역의 오른쪽 반을 클릭하면 즐겨찾기로 인식되는 문제 발견 → `flex`로 변경하여 하트 버튼(아이콘) 영역만 클릭되게끔 수정
2. `FavoriteGroupList` component
    - `select` emit 추가
    - selected, favoriteGroupStore.list 변경 시, 반영되도록 `watch`를 사용
3. `updateFavoriteGroupsInArchive` mutation 추가 
4. `CafeMap`, `ArchiveDetail` 화면 - 즐겨찾기 설정/해제 기능 구현 

### 🖥️ 화면(.gif) 
![2024-01-141 58 52-ezgif com-video-to-gif-converter](https://github.com/anniversaryArchive/archive/assets/31975198/6ba8d281-becd-47ba-9dae-c1b7b490f994)
